### PR TITLE
Fix pending RSVP, upload, mail, and dashboard regressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ model when applying the playbook's authentication and ownership guidance.
   access boundaries despite their similar names.
 - Owner-approved policy: unpublished events block guest RSVP additions and
   deletions, including deletion by a guest who previously owned a response.
-  Organizer editing and RSVP management remain available. Publication checks on
-  guest mutations are still missing; pending regressions cover the Phase 1.5 fix.
+  Organizer editing and RSVP management remain available. Public mutations enforce
+  publication before looking up or changing a response.
 
 Never import Bon App's accepted security risks as Easy RSVP owner decisions.
 Do not expose organizer links, tokens, credentials, or imported personal data in
@@ -59,11 +59,13 @@ eager-loading, asset-compilation, and RSpec checks.
 ## Code map and domain rules
 
 - `Event`: title/date validation, public hashid/slug, organizer token,
-  publication and RSVP-name visibility flags, `has_many :rsvps`.
+  publication and RSVP-name visibility flags, dependent destruction of RSVPs.
 - `Rsvp`: belongs to an event, name/response presence validation,
-  `RESPONSES = [:yes, :maybe, :no]`. Inclusion is not currently validated.
-- `ImageUpload`: one Active Storage image; uploads are handled independently
-  of event creation.
+  `RESPONSES = [:yes, :maybe, :no]`, with inclusion validation and a database check
+  for new writes. Historical rows still need review before validating the constraint.
+- `ImageUpload`: one required PNG/JPEG/GIF/WebP image, at most 10 MB. The upload
+  endpoint detects MIME type from file bytes. Upload ownership remains independent
+  of event creation and needs a separate lifecycle design.
 - `EventsController`: event creation and public display.
 - `EventsAdminController`: organizer display, editing, deletion, publication.
 - `RsvpsController`: public response creation and session-owned deletion.
@@ -71,8 +73,8 @@ eager-loading, asset-compilation, and RSpec checks.
 - `Admin::EmailRequestsController` / `UserMailer`: email the organizer link.
 - `Admin::EventsController` / `Admin::EventStats`: dashboard listing and stats.
   Owner-approved rule: yearly/monthly counts and projections measure event creation
-  using `created_at`, independent of scheduled `date`. Yearly counts comply; monthly
-  calculations still need the Phase 4.2 fix, covered by pending regressions.
+  using `created_at`, independent of scheduled `date`. Monthly numeric counts are
+  computed once per presenter and formatted for display.
 - `ImageUploadsController`: JSON upload endpoint for the editor.
 
 Use `db/schema.rb` and `config/routes.rb` for exact constraints and paths.
@@ -100,10 +102,9 @@ Firefox specs enable real CSRF protection and restore the setting afterward.
 Trix smoke specs use the real editor and native file-drop events, with real local
 upload/download requests. Never replace them with a stubbed successful upload.
 
-Known defects are executable `pending` regressions linked to assessment items.
-Remove each pending marker as its fix lands; an unexpected pass fails the suite.
+All 19 original pending regressions are fixed; the suite has no pending examples.
 Do not add pending markers for new failures without reproducing and documenting
-the defect. No application services exist under `app/services` today; the
+the defect. Regression expectations must continue to execute after fixes. No application services exist under `app/services` today; the
 production-database utility and command runner are unit-tested under `spec/lib`.
 
 `bin/dev` runs the Rails server. Development uploads use the configured S3 bucket

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Useful focused commands:
 ```sh
 bundle exec rspec --tag '~js'                 # fast model/request/feature/unit tests
 bundle exec rspec spec/system/javascript_smoke_spec.rb  # passing Firefox smoke flows
-bundle exec rspec --tag js                    # all Firefox specs, including known regressions
+bundle exec rspec --tag js                    # all Firefox smoke and failure-recovery specs
 bundle exec rspec --seed 18467                # reproduce a full-suite ordering
 ```
 
-The suite has 159 examples (19 known pending regressions) and covers models,
+The suite has 177 examples with no pending regressions and covers models,
 presenter units, mailers, HTTP requests, independent
 organizer/guest sessions, database-import services, Rack Test form flows, and
 real browser interactions. Firefox actually drops a PNG into Trix, submits it
@@ -66,14 +66,17 @@ suite, test email/jobs, and WebMock to reject external Ruby HTTP requests.
 WebDriver's localhost traffic is allowed. No production imports or real S3/SMTP
 operations are part of the suite.
 
-Known defects have executable `pending` expectations with assessment item IDs;
-they still run, and an unexpected pass fails the suite so the pending marker must
-be removed when the issue is fixed. They are separate from passing smoke coverage.
-The approved policy blocks guest RSVP additions/deletions on unpublished events
-while preserving organizer editing; two pending tests cover its missing enforcement.
-Dashboard counts and projections must use creation dates. Five pending regressions
-cover the monthly calculations that still use scheduled dates. Phase 0 coverage
-is complete; the documented application fixes remain outstanding.
+All 19 original pending expectations now pass. Guest RSVP additions/deletions are
+blocked on unpublished events while organizer editing remains available. Dashboard
+counts and projections use creation dates. Public image uploads require detected
+PNG/JPEG/GIF/WebP content and a maximum size of 10 MB; failed Trix uploads show an
+error and permit another attempt. Production email links require `DOMAIN` (a host
+without a URL scheme) and use HTTPS.
+
+The RSVP migration enforces supported response values on new writes using a
+PostgreSQL `NOT VALID` check constraint. It leaves historical records unchanged;
+review any invalid values before validating the existing rows in a later migration.
+The migration has been applied and reversed only against the local test database.
 
 `bin/ci` writes JUnit results to `tmp/test-results/rspec.xml`. Failed system tests
 save screenshots under `tmp/screenshots/`; CircleCI retains both. CircleCI deploys

--- a/app/assets/javascripts/trix_attachments.js
+++ b/app/assets/javascripts/trix_attachments.js
@@ -1,43 +1,55 @@
-document.addEventListener("turbolinks:load", function() {
-  Trix.config.attachments.preview.caption = {
-    name: false,
-    size: false
-  };
+(function() {
+  document.addEventListener("turbolinks:load", function() {
+    Trix.config.attachments.preview.caption = { name: false, size: false };
+  });
 
-  function uploadAttachment(attachment) {
-    var csrfToken = $('meta[name="csrf-token"]').attr('content');
-    var file = attachment.file;
-    var form = new FormData;
-    var endpoint = "/image_uploads";
-    form.append("Content-Type", file.type);
-    form.append("image_upload[image]", file);
+  function uploadAttachment(attachment, editor) {
+    var form = new FormData();
+    form.append("image_upload[image]", attachment.file);
 
-    xhr = new XMLHttpRequest;
-    xhr.open("POST", endpoint, true);
-    xhr.setRequestHeader("X-CSRF-Token", csrfToken);
+    var xhr = new XMLHttpRequest();
+    xhr.open("POST", "/image_uploads", true);
+    xhr.setRequestHeader("X-CSRF-Token", document.querySelector('meta[name="csrf-token"]').content);
+    xhr.timeout = 30000;
+
+    function clearError() {
+      var error = editor.parentNode.querySelector('.trix-upload-error');
+      if (error) error.remove();
+    }
+
+    function failUpload() {
+      clearError();
+      attachment.remove();
+      var error = document.createElement('div');
+      error.className = 'alert alert-danger trix-upload-error';
+      error.setAttribute('role', 'alert');
+      error.textContent = 'Image upload failed. Please try again with a PNG, JPEG, GIF, or WebP image (10 MB maximum).';
+      editor.insertAdjacentElement('afterend', error);
+    }
 
     xhr.upload.onprogress = function(event) {
-      var progress = event.loaded / event.total * 100;
-      return attachment.setUploadProgress(progress);
+      if (event.lengthComputable) attachment.setUploadProgress(event.loaded / event.total * 100);
     };
 
     xhr.onload = function() {
-      if (this.status >= 200 && this.status < 300) {
+      if (this.status < 200 || this.status >= 300) return failUpload();
+      try {
         var data = JSON.parse(this.responseText);
-        return attachment.setAttributes({
-          url: data.url,
-          href: data.url
-        });
+        if (typeof data.url !== 'string' || !data.url) return failUpload();
+        attachment.setAttributes({ url: data.url, href: data.url });
+        clearError();
+      } catch (error) {
+        failUpload();
       }
     };
+    xhr.onerror = failUpload;
+    xhr.ontimeout = failUpload;
+    xhr.onabort = failUpload;
+    xhr.send(form);
+  }
 
-    return xhr.send(form);
-  };
-
+  // Document listeners survive Turbolinks visits; register the handler once.
   document.addEventListener("trix-attachment-add", function(event) {
-    var attachment = event.attachment;
-    if (attachment.file) {
-      return uploadAttachment(attachment);
-    }
+    if (event.attachment.file) uploadAttachment(event.attachment, event.target);
   });
-});
+})();

--- a/app/controllers/image_uploads_controller.rb
+++ b/app/controllers/image_uploads_controller.rb
@@ -1,6 +1,17 @@
 class ImageUploadsController < ApplicationController
   def create
-    @image_upload = ImageUpload.new(image_upload_params)
+    attributes = image_upload_params
+    file = attributes[:image]
+    if file.present? && !file.is_a?(ActionDispatch::Http::UploadedFile)
+      render json: { image: ["must be an uploaded image file"] }, status: :unprocessable_entity
+      return
+    end
+
+    @image_upload = ImageUpload.new(attributes)
+    if file.present?
+      # Do not trust a client-supplied MIME type or filename extension.
+      @image_upload.image.blob.content_type = Marcel::MimeType.for(file.tempfile)
+    end
 
     respond_to do |format|
       if @image_upload.save

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -22,9 +22,13 @@ class RsvpsController < ApplicationController
 
     event_session = Array(session[@event.hashid])
 
-    if @rsvp.hashid.in?(event_session)
-      @rsvp.destroy
-      event_session -= [@rsvp.hashid]
+    if @rsvp.hashid.in?(event_session) && @rsvp.destroy
+      remaining = event_session - [@rsvp.hashid]
+      if remaining.empty?
+        session.delete(@event.hashid)
+      else
+        session[@event.hashid] = remaining
+      end
     end
 
     redirect_to @event

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -35,6 +35,7 @@ class RsvpsController < ApplicationController
   def set_event
     hashid = hashid_from_param(params[:event_id])
     @event = Event.find_by_hashid!(hashid)
+    raise ActiveRecord::RecordNotFound unless @event.published?
   end
 
   def rsvp_params

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -2,6 +2,8 @@ class RsvpsController < ApplicationController
   before_action :set_event
 
   def create
+    return head :bad_request unless params[:commit].is_a?(String)
+
     response = Rsvp::RESPONSES.find { |r| r == params[:commit].downcase.to_sym }
     @rsvp = @event.rsvps.new(rsvp_params.merge(response: response))
 
@@ -18,7 +20,7 @@ class RsvpsController < ApplicationController
   def destroy
     @rsvp = @event.rsvps.find(params[:id])
 
-    event_session = session[@event.hashid]
+    event_session = Array(session[@event.hashid])
 
     if @rsvp.hashid.in?(event_session)
       @rsvp.destroy
@@ -36,7 +38,11 @@ class RsvpsController < ApplicationController
   end
 
   def rsvp_params
-    params.require(:rsvp).permit(:name)
+    attributes = params.require(:rsvp)
+    unless attributes.is_a?(ActionController::Parameters)
+      raise ActionController::ParameterMissing, :rsvp
+    end
+    attributes.permit(:name)
   end
 
   def hashid_from_param(parameterized_id)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 class Event < ApplicationRecord
   include Hashid::Rails
 
-  has_many :rsvps
+  has_many :rsvps, dependent: :destroy
 
   before_create :set_admin_token
 

--- a/app/models/image_upload.rb
+++ b/app/models/image_upload.rb
@@ -1,3 +1,22 @@
 class ImageUpload < ApplicationRecord
+  CONTENT_TYPES = %w[image/png image/jpeg image/gif image/webp].freeze
+  MAXIMUM_SIZE = 10.megabytes
+
   has_one_attached :image
+
+  validate :acceptable_image
+
+  private
+
+  def acceptable_image
+    unless image.attached?
+      errors.add(:image, "must be attached")
+      return
+    end
+
+    unless CONTENT_TYPES.include?(image.blob.content_type)
+      errors.add(:image, "must be a PNG, JPEG, GIF, or WebP image")
+    end
+    errors.add(:image, "must be 10 MB or smaller") if image.blob.byte_size > MAXIMUM_SIZE
+  end
 end

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -10,7 +10,7 @@ class Rsvp < ApplicationRecord
   belongs_to :event
 
   validates :name, presence: true
-  validates :response, presence: true
+  validates :response, presence: true, inclusion: { in: RESPONSES.map(&:to_s) }
 
   # Use this to avoid including new (unsaved) records
   scope :persisted, -> { where.not(id: nil) }

--- a/app/presenters/admin/event_stats.rb
+++ b/app/presenters/admin/event_stats.rb
@@ -37,10 +37,7 @@ module Admin
 
     # Example: [["April 2024", "5"], ["March 2024", "10"], ["February 2024", "12"], ["January 2024", "8"]]
     def monthly_counts_with_labels
-      months = (0..months_back).map { |i| (now - i.months).beginning_of_month }
-      labels = months.map { |d| d.strftime("%B %Y") }
-      counts = months.map { |month| number_with_delimiter(count_events_in_month(month)) }
-      labels.zip(counts)
+      monthly_counts.map { |month, count| [month.strftime("%B %Y"), number_with_delimiter(count)] }
     end
 
     # Example: "March 2024: 10, February 2024: 12, January 2024: 8"
@@ -67,15 +64,18 @@ module Admin
 
       return current_month_count if days_so_far.zero?
 
-      # Convert current_month_count to integer for calculation, then format
-      extrapolated = (current_month_count.to_s.delete(',').to_f / days_so_far * days_in_month).round
+      extrapolated = (monthly_counts.first.last.to_f / days_so_far * days_in_month).round
       number_with_delimiter(extrapolated)
     end
 
     private
 
-    def count_events_in_month(month)
-      events.select { |e| e.date >= month && e.date < (month + 1.month) }.size
+    def monthly_counts
+      @monthly_counts ||= (0..months_back).map do |offset|
+        month = (now - offset.months).beginning_of_month
+        count = events.count { |event| event.created_at >= month && event.created_at < month + 1.month }
+        [month, count]
+      end
     end
   end
 end

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,13 +1,13 @@
 <div class="mb-3">
   <div>
-    <strong>Total events:</strong> <%= @event_stats.total_events %>
+    <strong>Total events created:</strong> <%= @event_stats.total_events %>
     (<%= @event_stats.yearly_counts_display %>)
   </div>
   <div>
-    <strong>Last <%= @event_stats.months_back %> full months:</strong> <%= @event_stats.full_months_display %>
+    <strong>Last <%= @event_stats.months_back %> full months (events created):</strong> <%= @event_stats.full_months_display %>
   </div>
   <div>
-    <strong>This month (<%= @event_stats.current_month_label %>):</strong>
+    <strong>This month (<%= @event_stats.current_month_label %>) — events created:</strong>
     <%= @event_stats.current_month_count %> so far,
     extrapolated: <%= @event_stats.extrapolated_current_month_count %>
   </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: ENV.fetch("DOMAIN"), protocol: "https" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/db/migrate/20260908140000_add_supported_response_constraint_to_rsvps.rb
+++ b/db/migrate/20260908140000_add_supported_response_constraint_to_rsvps.rb
@@ -1,0 +1,10 @@
+class AddSupportedResponseConstraintToRsvps < ActiveRecord::Migration[8.1]
+  def change
+    # Protect new writes without scanning or rewriting historical responses.
+    # Validate the existing rows separately after any invalid values are reviewed.
+    add_check_constraint :rsvps,
+      "response IS NOT NULL AND response IN ('yes', 'maybe', 'no')",
+      name: "rsvps_supported_response",
+      validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,30 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_15_112908) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_08_140000) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
-  enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", precision: nil, null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -45,14 +45,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_15_112908) do
   end
 
   create_table "events", force: :cascade do |t|
-    t.string "title", null: false
-    t.date "date", null: false
-    t.text "body"
     t.string "admin_token", null: false
+    t.text "body"
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.boolean "show_rsvp_names", default: true, null: false
+    t.date "date", null: false
     t.boolean "published", default: true
+    t.boolean "show_rsvp_names", default: true, null: false
+    t.string "title", null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "image_uploads", force: :cascade do |t|
@@ -61,13 +61,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_15_112908) do
   end
 
   create_table "rsvps", force: :cascade do |t|
+    t.datetime "created_at", precision: nil, null: false
     t.bigint "event_id"
     t.string "name"
     t.string "response"
-    t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["event_id"], name: "index_rsvps_on_event_id"
   end
+
+  add_check_constraint "rsvps", "response IS NOT NULL AND (response::text = ANY (ARRAY['yes'::character varying, 'maybe'::character varying, 'no'::character varying]::text[]))", name: "rsvps_supported_response", validate: false
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "rsvps", "events"

--- a/docs/CODEBASE_ASSESSMENT.md
+++ b/docs/CODEBASE_ASSESSMENT.md
@@ -4,9 +4,46 @@ Assessed **2026-09-08**, branch `main`, commit `38413a5`, including the existing
 uncommitted playbook/agent documentation, README/environment additions, and
 production-database pull implementation/specs from the preceding task.
 
-Status: **assessment and Phase 0 coverage complete; product remediation remains pending**. This replaces the
+Status: **assessment and Phase 0 coverage complete; original pending regressions fixed; broader remediation remains**. This replaces the
 initial assessment brief. Standards: [Rails Engineering Playbook](RAILS_ENGINEERING_PLAYBOOK.md).
 Application reference: [AGENTS.md](../AGENTS.md).
+
+## Pending-regression remediation — 2026-09-08
+
+Starting from merged PR #868 (`1e516fd`), the 19 pending expectations were removed
+one defect group at a time in priority-ordered commits. All now pass. The fixes are:
+
+1. P1 upload validation: required PNG/JPEG/GIF/WebP content detected from file bytes,
+   with a 10 MB limit and no upload record created for rejected input.
+2. P1 RSVP request guards: missing/non-string submit values, malformed nested
+   parameters, and absent ownership sessions receive controlled responses.
+3. P1 response integrity: model inclusion and a PostgreSQL check constrain new
+   writes, including writes that bypass model validation.
+4. P1 event deletion: dependent RSVP destruction runs within the event transaction.
+5. P1 mail links: production uses the configured `DOMAIN` and HTTPS.
+6. P1 Trix uploads: one document listener, local XHR state, and visible recovery for
+   rejected files, network errors, timeouts, and malformed JSON responses.
+7. P2 publication and session state: unpublished guest writes are blocked;
+   successful deletion removes only the relevant ownership ID and drops empty keys.
+8. P2 statistics: yearly/monthly counts and projections use creation timestamps;
+   monthly numeric counts are computed once and the UI labels creation metrics.
+
+Validation: `CI=true bin/ci --seed 56913` passes eager loading, asset compilation,
+and **177 examples, 0 failures, 0 pending** (13.46 seconds of RSpec execution).
+The added Firefox coverage includes real Turbolinks navigation, a real rejected
+upload followed by a successful upload, and injected transport failures followed
+by retries through the actual endpoint/storage. The database migration was tested
+up/down/up only against `events_test`. No production data was accessed or changed.
+
+The response constraint is intentionally `NOT VALID`: it protects new writes
+without scanning, rewriting, or silently coercing historical responses. Item 1.4
+remains partial until old invalid values are reviewed and the constraint is
+validated. Upload ownership/expiry, direct-upload route policy, and request-level
+abuse limits also remain in 2.4. Dependency patches, vendored Trix replacement,
+log redaction, and the other unchecked assessment items are separate work.
+
+Earlier sections below are dated evidence snapshots, including their historical
+pending counts and descriptions of defects before these fixes.
 
 ## Creation-date policy and Phase 0 completion — 2026-09-08
 
@@ -299,7 +336,7 @@ provided; Bon App's accepted risks do not transfer.
 
 ## Phase 1 — Correctness and proven bit-rot
 
-- [ ] **1.1 P1 — Repair event deletion.** `Event` has `has_many :rsvps` without a
+- [x] **1.1 P1 — Repair event deletion.** Completed in the remediation above; original finding follows. `Event` has `has_many :rsvps` without a
   dependent policy (`app/models/event.rb:4`), while `rsvps.event_id` has a foreign
   key (`db/schema.rb:73`). `EventsAdminController#destroy` at line 19 calls
   `@event.destroy`. A token-authorized DELETE of an event with one RSVP raises
@@ -308,7 +345,7 @@ provided; Bon App's accepted risks do not transfer.
   and unauthorized deletion. This route exists even though no event-delete
   control is currently rendered.
 
-- [ ] **1.2 P1 — Handle malformed RSVP submissions and absent session ownership.**
+- [x] **1.2 P1 — Handle malformed RSVP submissions and absent session ownership.** Completed in the remediation above; original finding follows.
   `app/controllers/rsvps_controller.rb:5` calls `downcase` on `params[:commit]`
   without validating its presence/type. Missing `commit` raises `NoMethodError`.
   Lines 23–25 pass a missing session entry into `in?`, raising `ArgumentError`
@@ -316,13 +353,15 @@ provided; Bon App's accepted risks do not transfer.
   controlled response; treat a missing ownership list as empty and preserve the
   response. Test nil, wrong-shaped values, unsupported answers, and denied deletes.
 
-- [ ] **1.3 P2 — Persist session cleanup after RSVP deletion.** Line 27 reassigns
+- [x] **1.3 P2 — Persist session cleanup after RSVP deletion.** Completed in the remediation above; original finding follows. Line 27 reassigns
   `event_session -= [@rsvp.hashid]` but never writes it back to `session`.
   The record disappears while the cookie's ownership array retains its hashid.
   Repeated use grows stale session data. Store the reduced array or delete an
   empty key; test both database state and subsequent session contents.
 
-- [ ] **1.4 P1 — Validate response membership.** `app/models/rsvp.rb:13` only
+- [ ] **1.4 P1 — Validate response membership.** Model validation and the check
+  constraint for new writes are implemented. Remaining: review historical invalid
+  responses and validate the constraint; no automatic data coercion. Original finding: `app/models/rsvp.rb:13` only
   validates response presence. The organizer endpoint permits `response`
   (`app/controllers/admin/rsvps_controller.rb:26`). A PATCH with `unexpected`
   persists successfully; the public view only groups yes/maybe/no and omits
@@ -330,7 +369,7 @@ provided; Bon App's accepted risks do not transfer.
   a safe data cleanup/migration, and a database check constraint; test model,
   request, and direct-database writes. Do not silently coerce existing bad data.
 
-- [ ] **1.5 P2 — Enforce the approved unpublished-event write policy.** Public
+- [x] **1.5 P2 — Enforce the approved unpublished-event write policy.** Completed in the remediation above; original finding follows. Public
   display checks `published?` (`app/controllers/events_controller.rb:34`), but
   `RsvpsController#set_event` does not. The owner confirmed that unpublishing blocks
   guest creation and deletion of RSVPs, including previously session-owned responses.
@@ -338,7 +377,7 @@ provided; Bon App's accepted risks do not transfer.
   pending request regressions reproduce actual writes; implement the guard and
   remove their pending markers. Republishing must restore guest RSVP access.
 
-- [ ] **1.6 P1 — Fix production email link hosts.**
+- [x] **1.6 P1 — Fix production email link hosts.** Completed in the remediation above; original finding follows.
   `config/environments/production.rb:60` hardcodes `example.com`, overriding
   `config/application.rb`'s `DOMAIN`. A local production boot confirmed this
   even with a nonempty synthetic `DOMAIN`. `UserMailer` renders both organizer
@@ -348,7 +387,7 @@ provided; Bon App's accepted risks do not transfer.
   email journey is commented out; decide whether to restore that feature or
   remove the unused endpoint in a separate product decision.
 
-- [ ] **1.7 P1 — Register one attachment handler per document lifecycle.**
+- [x] **1.7 P1 — Register one attachment handler per document lifecycle.** Completed in the remediation above; original finding follows.
   `app/assets/javascripts/trix_attachments.js:37` adds a document listener inside
   every `turbolinks:load`. In Firefox, three additional load events followed by
   one synthetic attachment event triggered **four upload sends**, intercepted
@@ -404,7 +443,9 @@ provided; Bon App's accepted risks do not transfer.
   Prove redaction with synthetic tokens and review logging configurations. Merely
   adding another filtered parameter does not fix raw path logging.
 
-- [ ] **2.4 P1 — Bound and own public uploads.**
+- [ ] **2.4 P1 — Bound and own public uploads.** Presence, detected content types,
+  a 10 MB limit, and recoverable upload errors are implemented. Ownership/expiry,
+  direct-upload policy, and request-level abuse controls remain. Original finding:
   `ImageUploadsController#create` permits any file and `ImageUpload` has no
   presence/type/size validation. A public JSON upload of a plain text file returned
   200 and persisted it. The app also exposes Rails direct-upload routes. Define
@@ -452,7 +493,7 @@ provided; Bon App's accepted risks do not transfer.
   Add a scale test that limits instantiated rows as well as query count; a
   constant query count alone would let the present problem pass.
 
-- [ ] **4.2 P2 — Use creation timestamps consistently for dashboard counts.**
+- [x] **4.2 P2 — Use creation timestamps consistently for dashboard counts.** Completed in the remediation above; original finding follows.
   `Admin::EventStats#yearly_counts` groups by `created_at.year` (line 29), but
   `count_events_in_month` uses the event's scheduled `date` (line 78).
   A January-created, September-scheduled event counts as a September event.

--- a/spec/config/production_mail_spec.rb
+++ b/spec/config/production_mail_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'Production mail URL configuration' do
     deployment_host = 'deployment.example.test'
     allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with('DOMAIN').and_return(deployment_host)
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('DOMAIN').and_return(deployment_host)
     isolated_application = EasyRsvp::Application.new
     isolated_application.config.action_mailer.default_url_options = { host: deployment_host }
     allow(Rails.application).to receive(:configure) do |&configuration|
@@ -19,10 +21,10 @@ RSpec.describe 'Production mail URL configuration' do
     event = create(:event)
     message = UserMailer.admin_url_request_email('guest@example.test', event)
 
-    pending 'Assessment 1.6: production overrides the deployment mail host with example.com'
     expect(options.fetch(:host)).to eq(deployment_host)
-    expect(message.body.decoded).to include("#{deployment_host}/#{event.to_param}")
-    expect(message.body.decoded).to include("#{deployment_host}/#{event.to_param}/admin/#{event.admin_token}")
+    expect(options.fetch(:protocol)).to eq('https')
+    expect(message.body.decoded).to include("https://#{deployment_host}/#{event.to_param}")
+    expect(message.body.decoded).to include("https://#{deployment_host}/#{event.to_param}/admin/#{event.admin_token}")
     expect(ActionMailer::Base.deliveries).to be_empty
   end
 end

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -19,7 +19,7 @@ describe 'admin dashboard stats', type: :feature do
     visit '/admin/events'
 
     # Total events
-    expect(page).to have_content("Total events:")
+    expect(page).to have_content("Total events created:")
     expect(page).to have_content("2021: 1")
     expect(page).to have_content("2022: 1")
     expect(page).to have_content("#{Date.today.year}: 4")

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe Event, type: :model do
   end
 
   it 'deletes an event and its responses together' do
-    pending 'Assessment 1.1: Event has no dependent RSVP deletion policy'
     event = create(:rsvp).event
     expect { event.destroy! }.to change(Rsvp, :count).by(-1)
     expect(described_class.exists?(event.id)).to be(false)

--- a/spec/models/image_upload_spec.rb
+++ b/spec/models/image_upload_spec.rb
@@ -26,14 +26,23 @@ RSpec.describe ImageUpload, type: :model do
   end
 
   it 'requires a file' do
-    pending 'Assessment 2.4: ImageUpload has no attachment presence validation'
     expect(described_class.new).not_to be_valid
   end
 
   it 'rejects a non-image attachment' do
-    pending 'Assessment 2.4: ImageUpload has no content-type validation'
     upload = described_class.new
     upload.image.attach(io: File.open(Rails.root.join('spec/fixtures/files/notes.txt')), filename: 'notes.txt', content_type: 'text/plain')
     expect(upload).not_to be_valid
   end
+
+  [10.megabytes, 10.megabytes + 1].each do |size|
+    it "enforces the 10 MB limit for a #{size}-byte image" do
+      bytes = File.binread(Rails.root.join('spec/fixtures/files/party.png')).ljust(size, "\0")
+      upload = described_class.new
+      upload.image.attach(io: StringIO.new(bytes), filename: 'large.png', content_type: 'image/png')
+      expect(upload.valid?).to eq(size <= 10.megabytes)
+      expect(upload.errors[:image]).to include('must be 10 MB or smaller') if size > 10.megabytes
+    end
+  end
+
 end

--- a/spec/models/rsvp_spec.rb
+++ b/spec/models/rsvp_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Rsvp, type: :model do
   end
 
   it 'rejects answers outside the supported choices' do
-    pending 'Assessment 1.4: response membership is not validated'
     expect(build(:rsvp, response: 'unexpected')).not_to be_valid
   end
 
@@ -49,4 +48,15 @@ RSpec.describe Rsvp, type: :model do
     end.to raise_error(ActiveRecord::InvalidForeignKey)
     expect(rsvp.reload.event).to be_present
   end
+
+  [nil, 'unexpected'].each do |answer|
+    it "rejects #{answer.inspect} even when model validation is bypassed" do
+      rsvp = create(:rsvp)
+      expect do
+        described_class.transaction(requires_new: true) { rsvp.update_column(:response, answer) }
+      end.to raise_error(ActiveRecord::StatementInvalid) { |error| expect(error.cause).to be_a(PG::CheckViolation) }
+      expect(rsvp.reload.response).to eq('yes')
+    end
+  end
+
 end

--- a/spec/presenters/admin/event_stats_spec.rb
+++ b/spec/presenters/admin/event_stats_spec.rb
@@ -73,14 +73,12 @@ RSpec.describe Admin::EventStats do
         entry(date: Date.new(2026, 12, 5), created_at: Time.zone.local(2026, 9, 3)),
         entry(date: Date.new(2026, 9, 5), created_at: Time.zone.local(2026, 8, 20))
       ]
-      pending 'Assessment 4.2: monthly statistics use scheduled dates instead of creation timestamps'
       expect(described_class.new(rows, now: now).current_month_count).to eq('2')
     end
 
     it 'puts a December creation in December history even when the party is in January' do
       rows = [entry(date: Date.new(2027, 1, 5), created_at: Time.zone.local(2026, 12, 20))]
       stats = described_class.new(rows, now: Time.zone.local(2027, 1, 10), months_back: 1)
-      pending 'Assessment 4.2: monthly statistics use scheduled dates instead of creation timestamps'
       expect(stats.monthly_counts_with_labels).to eq([['January 2027', '0'], ['December 2026', '1']])
     end
 
@@ -91,7 +89,6 @@ RSpec.describe Admin::EventStats do
         entry(date: Date.new(2026, 11, 5), created_at: Time.zone.local(2026, 10, 1))
       ]
       stats = described_class.new(rows, now: Time.zone.local(2026, 9, 30, 23, 59, 59))
-      pending 'Assessment 4.2: monthly statistics use scheduled dates instead of creation timestamps'
       expect(stats.current_month_count).to eq('2')
     end
 
@@ -99,7 +96,6 @@ RSpec.describe Admin::EventStats do
       event = entry(date: Date.new(2026, 9, 5), created_at: Time.zone.local(2026, 9, 2))
       original = described_class.new([event], now: now).monthly_counts_with_labels
       event.date = Date.new(2026, 11, 5)
-      pending 'Assessment 4.2: monthly statistics use scheduled dates instead of creation timestamps'
       expect(described_class.new([event], now: now).monthly_counts_with_labels).to eq(original)
     end
 
@@ -108,7 +104,6 @@ RSpec.describe Admin::EventStats do
         entry(date: Date.new(2026, 11, 5), created_at: Time.zone.local(2026, 9, 2))
       end
       rows << entry(date: Date.new(2026, 9, 25), created_at: Time.zone.local(2026, 8, 20))
-      pending 'Assessment 4.2: monthly statistics use scheduled dates instead of creation timestamps'
       expect(described_class.new(rows, now: now).extrapolated_current_month_count).to eq('15')
     end
   end

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Site administrator dashboard', type: :request do
   it 'renders an empty state without broken statistics' do
     get admin_events_path, headers: dashboard_headers
     expect(response).to have_http_status(:ok)
-    expect(response.body).to match(/Total events:<\/strong>\s*0/)
+    expect(response.body).to match(/Total events created:<\/strong>\s*0/)
   end
 
   it 'does not introduce N+1 queries as the listing grows' do
@@ -42,4 +42,15 @@ RSpec.describe 'Site administrator dashboard', type: :request do
     expect(large).to eq(small)
     expect(large).to be <= 3
   end
+
+  it 'shows creation counts even when all parties are scheduled in another month' do
+    travel_to Time.zone.local(2026, 9, 10, 12)
+    create_list(:event, 2, date: Date.new(2026, 11, 5), created_at: Time.zone.local(2026, 9, 2))
+    create(:event, date: Date.new(2026, 9, 20), created_at: Time.zone.local(2026, 8, 2))
+    get admin_events_path, headers: dashboard_headers
+    text = Nokogiri::HTML(response.body).text.squish
+    expect(text).to include('Total events created: 3', 'August 2026: 1')
+    expect(text).to include('This month (September 2026) — events created: 2 so far, extrapolated: 6')
+  end
+
 end

--- a/spec/requests/admin/rsvps_spec.rb
+++ b/spec/requests/admin/rsvps_spec.rb
@@ -46,4 +46,14 @@ RSpec.describe 'Organizer RSVP management', type: :request do
       expect(rsvp.reload.attributes).to eq(original)
     end
   end
+
+  it 'rejects unsupported responses without changing the guest or hiding their RSVP' do
+    original = rsvp.reload.attributes
+    patch event_admin_rsvp_path(event, event.admin_token, rsvp), params: { rsvp: { name: 'Changed', response: 'unexpected' } }
+    expect(rsvp.reload.attributes).to eq(original)
+    expect(flash[:alert]).to include('could not be updated')
+    get event_path(event)
+    expect(response.body).to include(rsvp.name)
+  end
+
 end

--- a/spec/requests/image_uploads_spec.rb
+++ b/spec/requests/image_uploads_spec.rb
@@ -31,4 +31,22 @@ RSpec.describe 'Image upload integration', type: :request do
     expect { post image_uploads_path(format: :json), params: {} }.not_to change(ImageUpload, :count)
     expect(response).to have_http_status(:bad_request)
   end
+
+  it 'rejects a non-image even when its submitted MIME type claims it is a PNG' do
+    file = fixture_file_upload(Rails.root.join('spec/fixtures/files/notes.txt'), 'image/png')
+    expect do
+      post image_uploads_path(format: :json), params: { image_upload: { image: file } }
+    end.not_to change(ImageUpload, :count)
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.parsed_body.fetch('image')).to be_present
+    expect(ActiveStorage::Blob.count).to eq(0)
+  end
+
+  it 'rejects a blank file without leaving an upload record behind' do
+    expect do
+      post image_uploads_path(format: :json), params: { image_upload: { image: '' } }
+    end.not_to change(ImageUpload, :count)
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
 end

--- a/spec/requests/malformed_rsvps_spec.rb
+++ b/spec/requests/malformed_rsvps_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Malformed public RSVP requests', type: :request do
 
   ['', [], ['Yes'], { answer: 'Yes' }].each do |submit|
     it "rejects submit value #{submit.inspect} without saving or claiming ownership" do
-      pending 'Assessment 1.2: non-string submit values raise NoMethodError' unless submit.is_a?(String)
       expect do
         post event_rsvps_path(event), params: { rsvp: { name: 'Guest' }, commit: submit }
       end.not_to change(Rsvp, :count)
@@ -49,6 +48,15 @@ RSpec.describe 'Malformed public RSVP requests', type: :request do
     end.not_to change(Rsvp, :count)
     expect(response).to redirect_to(event)
     expect(request.session[event.hashid]).to eq([])
+  end
+
+  ['invalid', ['invalid']].each do |attributes|
+    it "rejects malformed RSVP attributes #{attributes.inspect}" do
+      expect do
+        post event_rsvps_path(event), params: { rsvp: attributes, commit: 'Yes' }
+      end.not_to change(Rsvp, :count)
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 
 end

--- a/spec/requests/organizer_events_spec.rb
+++ b/spec/requests/organizer_events_spec.rb
@@ -65,4 +65,24 @@ RSpec.describe 'Organizer events', type: :request do
     expect(response).to have_http_status(:not_found)
     expect(event.reload).to be_published
   end
+
+  it 'deletes an event and its responses without touching another events responses' do
+    create_list(:rsvp, 2, event: event)
+    other = create(:rsvp)
+    expect do
+      delete event_admin_path(event, event.admin_token)
+    end.to change(Event, :count).by(-1).and change(Rsvp, :count).by(-2)
+    expect(response).to redirect_to(root_path)
+    expect(Rsvp.exists?(other.id)).to be(true)
+  end
+
+  it 'preserves responses when event deletion uses the wrong token' do
+    rsvp = create(:rsvp, event: event)
+    expect do
+      delete event_admin_path(event, 'wrong')
+    end.not_to change(Rsvp, :count)
+    expect(response).to have_http_status(:not_found)
+    expect(rsvp.reload.event).to eq(event)
+  end
+
 end

--- a/spec/requests/rsvps_spec.rb
+++ b/spec/requests/rsvps_spec.rb
@@ -59,11 +59,10 @@ RSpec.describe 'Public RSVPs', type: :request do
   end
 
   it 'removes a deleted response from the ownership session' do
-    pending 'Assessment 1.3: deletion reassigns a local array, not the session'
     post event_rsvps_path(event), params: { rsvp: { name: 'Mine' }, commit: 'Yes' }
     own = event.rsvps.last
     delete event_rsvp_path(event, own)
-    expect(Array(request.session[event.hashid])).not_to include(own.hashid)
+    expect(request.session[event.hashid]).to be_nil
   end
 
   it 'rejects a response ID belonging to another event' do
@@ -80,4 +79,22 @@ RSpec.describe 'Public RSVPs', type: :request do
     expect(response.body).to include('My guest')
     expect(response.body).not_to include('Hidden guest')
   end
+
+  it 'keeps other owned responses and other event sessions when deleting one RSVP' do
+    other_event = create(:event)
+    post event_rsvps_path(other_event), params: { rsvp: { name: 'Elsewhere' }, commit: 'Yes' }
+    elsewhere = other_event.rsvps.last
+    post event_rsvps_path(event), params: { rsvp: { name: 'First' }, commit: 'Yes' }
+    first = event.rsvps.last
+    post event_rsvps_path(event), params: { rsvp: { name: 'Second' }, commit: 'Maybe' }
+    second = event.rsvps.last
+
+    delete event_rsvp_path(event, first)
+    expect(request.session[event.hashid]).to eq([second.hashid])
+    expect(request.session[other_event.hashid]).to eq([elsewhere.hashid])
+    delete event_rsvp_path(event, second)
+    expect(request.session[event.hashid]).to be_nil
+    expect(request.session[other_event.hashid]).to eq([elsewhere.hashid])
+  end
+
 end

--- a/spec/requests/rsvps_spec.rb
+++ b/spec/requests/rsvps_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe 'Public RSVPs', type: :request do
   end
 
   it 'handles a missing submit value without crashing' do
-    pending 'Assessment 1.2: nil commit raises NoMethodError'
     post event_rsvps_path(event), params: { rsvp: { name: 'Alex' } }
     expect(response).to have_http_status(:bad_request)
     expect(event.rsvps).to be_empty
@@ -54,7 +53,6 @@ RSpec.describe 'Public RSVPs', type: :request do
   end
 
   it 'denies deletion by a visitor with no ownership session without crashing' do
-    pending 'Assessment 1.2: nil event session raises ArgumentError'
     rsvp = create(:rsvp, event: event)
     expect { delete event_rsvp_path(event, rsvp) }.not_to change(Rsvp, :count)
     expect(response).to redirect_to(event)

--- a/spec/requests/unpublished_rsvps_spec.rb
+++ b/spec/requests/unpublished_rsvps_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'RSVP access while an event is unpublished', type: :request do
   let!(:event) { create(:event, :unpublished) }
 
   it 'blocks guest additions without saving a response or claiming ownership' do
-    pending 'Assessment 1.5: guest additions ignore event publication'
     expect do
       post event_rsvps_path(event), params: { rsvp: { name: 'Guest' }, commit: 'Yes' }
     end.not_to change(Rsvp, :count)
@@ -18,7 +17,6 @@ RSpec.describe 'RSVP access while an event is unpublished', type: :request do
     rsvp = event.rsvps.last
     event.update!(published: false)
 
-    pending 'Assessment 1.5: guest deletion ignores event publication'
     expect { delete event_rsvp_path(event, rsvp) }.not_to change(Rsvp, :count)
     expect(response).to have_http_status(:not_found)
     expect(request.session[event.hashid]).to include(rsvp.hashid)

--- a/spec/system/upload_regressions_spec.rb
+++ b/spec/system/upload_regressions_spec.rb
@@ -14,7 +14,73 @@ RSpec.describe 'Upload lifecycle regressions', type: :system, js: true do
     JS
     find('trix-editor').drop(Rails.root.join('spec/fixtures/files/party.png').to_s)
     expect(page).to have_css('trix-editor img[src*="/rails/active_storage/"]')
-    pending 'Assessment 1.7: every turbolinks:load registers another upload handler'
     expect(page.evaluate_script('window.uploadStarts')).to eq(1)
   end
+
+  it 'uploads only once after navigating between organizer, edit, and new pages' do
+    event = create(:event)
+    visit event_admin_path(event, event.admin_token)
+    page.execute_script("window.specDocumentMarker = 'same-document'")
+    click_link 'Edit', match: :first
+    expect(page).to have_button('Update Event')
+    find('.navbar-brand').click
+    expect(page).to have_button('Create your event, for free!')
+    page.go_back
+    expect(page).to have_button('Update Event')
+    find('.navbar-brand').click
+    expect(page).to have_button('Create your event, for free!')
+    expect(page.evaluate_script('window.specDocumentMarker')).to eq('same-document')
+    find('trix-editor').drop(Rails.root.join('spec/fixtures/files/party.png').to_s)
+    expect(page).to have_css('trix-editor img[src*="/rails/active_storage/"]')
+    expect(ImageUpload.count).to eq(1)
+    expect(page.evaluate_script('typeof window.xhr')).to eq('undefined')
+  end
+
+  it 'shows a rejected upload and permits a successful retry with a real image' do
+    visit root_path
+    find('trix-editor').drop(Rails.root.join('spec/fixtures/files/notes.txt').to_s)
+    expect(page).to have_css('[role=alert]', text: 'Image upload failed')
+    expect(ImageUpload.count).to eq(0)
+    find('trix-editor').drop(Rails.root.join('spec/fixtures/files/party.png').to_s)
+    expect(page).to have_css('trix-editor img[src*="/rails/active_storage/"]')
+    expect(page).to have_no_css('.trix-upload-error')
+    expect(ImageUpload.count).to eq(1)
+  end
+
+  %w[error timeout invalid_json].each do |failure|
+    it "recovers from an upload #{failure} without leaving a stuck attachment" do
+      visit root_path
+      # Inject only the failed transport; the retry uses the real endpoint/storage.
+      page.execute_script(<<~JS, failure)
+        const failure = arguments[0];
+        const originalOpen = XMLHttpRequest.prototype.open;
+        const originalSend = XMLHttpRequest.prototype.send;
+        XMLHttpRequest.prototype.open = function(method, url) {
+          this.specUpload = method === 'POST' && url === '/image_uploads';
+          return originalOpen.apply(this, arguments);
+        };
+        XMLHttpRequest.prototype.send = function() {
+          if (!this.specUpload) return originalSend.apply(this, arguments);
+          XMLHttpRequest.prototype.open = originalOpen;
+          XMLHttpRequest.prototype.send = originalSend;
+          if (failure === 'invalid_json') {
+            Object.defineProperty(this, 'status', { value: 200 });
+            Object.defineProperty(this, 'responseText', { value: 'broken json' });
+            this.dispatchEvent(new Event('load'));
+          } else {
+            this.dispatchEvent(new Event(failure));
+          }
+        };
+      JS
+      find('trix-editor').drop(Rails.root.join('spec/fixtures/files/party.png').to_s)
+      expect(page).to have_css('[role=alert]', text: 'Image upload failed')
+      expect(page).to have_no_css('trix-editor figure')
+      expect(ImageUpload.count).to eq(0)
+      find('trix-editor').drop(Rails.root.join('spec/fixtures/files/party.png').to_s)
+      expect(page).to have_css('trix-editor img[src*="/rails/active_storage/"]')
+      expect(page).to have_no_css('.trix-upload-error')
+      expect(ImageUpload.count).to eq(1)
+    end
+  end
+
 end


### PR DESCRIPTION
All 19 pending regression expectations now pass. Invalid RSVP requests return controlled responses, unpublished events block guest writes, event deletion removes its RSVPs, uploads are validated and recover from failures, production emails use the configured HTTPS host, and dashboard statistics consistently count creation dates.

The fixes are separate commits in priority order:

- P1: require detected PNG/JPEG/GIF/WebP uploads up to 10 MB; reject blank files and spoofed MIME types without creating upload records.
- P1: guard malformed RSVP input and missing ownership sessions; validate response membership in the model and enforce it on new database writes.
- P1: destroy event responses transactionally, generate production links from `DOMAIN` over HTTPS, and register one Trix upload handler per document.
- P1: show recoverable upload errors for rejected files, network failures, timeouts, and malformed JSON; successful retries still use the real endpoint and storage.
- P2: enforce the approved unpublished-event policy, persist ownership-session cleanup, and use creation timestamps for numeric dashboard counts/projections and their labels.

Validation: `CI=true bin/ci --seed 56913` passes eager loading, asset compilation, and **177 examples, 0 failures, 0 pending**. Each defect group was tested before its fix and then verified independently. Additional coverage includes native Firefox file drops after real Turbolinks navigation, rejected uploads and transport-failure recovery, malformed nested parameters, database writes bypassing validation, event/session isolation, and dashboard rendering. The migration was tested up/down/up against `events_test`. `git diff --check` passes. CircleCI [build 1844](https://circleci.com/gh/KevinBongart/easy-rsvp/1844) also passed, including database setup from the schema, assets, all tests, and artifact upload.

The new PostgreSQL response constraint is deliberately `NOT VALID`: it protects new writes without scanning or silently changing historical data. Existing invalid responses still need review before validating the constraint in a later migration. Production now requires `DOMAIN` to be configured as a hostname. No production data was accessed, no database import was run, and no deployment was performed.

The assessment distinguishes these completed regressions from remaining work: historical response review, upload ownership/expiry and direct-upload policy, abuse controls, dependency patches, vendored Trix replacement, and log redaction.
