### PR TITLE
Add compact admin charts with actual counts and projections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,17 @@ eager-loading, asset-compilation, and RSpec checks.
 - `Admin::EventsController` / `Admin::EventStats`: dashboard listing and stats.
   Owner-approved rule: yearly/monthly counts and projections measure event creation
   using `created_at`, independent of scheduled `date`. Monthly numeric counts are
-  computed once per presenter and formatted for display.
+  computed once per presenter and formatted for display. The dashboard uses
+  server-rendered 160 × 20 SVG sparklines with CSS hover/focus tooltips (no chart
+  JavaScript). The yearly chart includes a separate actual point through today
+  before its dashed December 31 projection. The monthly history ends with a dashed
+  current-period projection;
+  the current-month chart shows cumulative daily counts followed by a dashed
+  forecast. Projections use the average per elapsed calendar day, including today,
+  and account for month/year length. Missing periods are zero-filled. Monthly
+  history includes 12 completed months plus the current projection. The all-time
+  total includes the oldest creation date; current-year and current-month counts
+  and projections are visible beside their charts.
 - `ImageUploadsController`: JSON upload endpoint for the editor.
 
 Use `db/schema.rb` and `config/routes.rb` for exact constraints and paths.
@@ -99,6 +109,9 @@ WebMock, allowing localhost for WebDriver. Active Storage uses a dedicated
 temporary disk directory, mail uses test delivery, and jobs use the test adapter.
 System specs default to Rack Test; add `js: true` only for browser behavior.
 Firefox specs enable real CSRF protection and restore the setting afterward.
+Development and test resolve assets from current source, bypassing precompiled
+manifests left by local CI. The development asset regression boots that environment
+separately and checks stylesheet delivery without accessing application data.
 Trix smoke specs use the real editor and native file-drop events, with real local
 upload/download requests. Never replace them with a stubbed successful upload.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ bundle exec rspec --tag js                    # all Firefox smoke and failure-re
 bundle exec rspec --seed 18467                # reproduce a full-suite ordering
 ```
 
-The suite has 177 examples with no pending regressions and covers models,
+The suite has no pending regressions and covers models,
 presenter units, mailers, HTTP requests, independent
 organizer/guest sessions, database-import services, Rack Test form flows, and
 real browser interactions. Firefox actually drops a PNG into Trix, submits it
@@ -59,6 +59,11 @@ an event, reloads the public page, and edits text while preserving the image.
 Clipboard, RSVP-again, Bootstrap modals, and Rails UJS deletion also have smoke
 coverage. Firefox specs enable real CSRF protection, including for uploads.
 Browser specs resolve current asset source even if compiled files exist.
+Development also resolves current asset source so local CI precompilation cannot
+leave it serving stale styles or scripts. Restart an already running development
+server after changing environment configuration (`bin/rails restart` for Puma).
+Admin chart coverage checks real Firefox hover/focus tooltips, navigation, empty
+data, and narrow layouts, alongside unit tests for projections and chart scaling.
 
 Tests require local `events_test`. They use synthetic dashboard credentials,
 transactional records, a temporary disk storage directory removed after the
@@ -77,6 +82,17 @@ The RSVP migration enforces supported response values on new writes using a
 PostgreSQL `NOT VALID` check constraint. It leaves historical records unchanged;
 review any invalid values before validating the existing rows in a later migration.
 The migration has been applied and reversed only against the local test database.
+
+The admin dashboard shows the all-time total with its earliest creation date,
+current-year count and projection, and current-month count and projection alongside
+three compact blue charts: annual counts, the last 12 completed months plus this month,
+and this month's running daily total. Solid lines show actual counts; dashed
+segments show extrapolations at the current average per calendar day (including
+today). Hover, tap, or keyboard-focus a point for its count; the current endpoint
+of the monthly history includes both the actual count so far and the estimated final total.
+The yearly chart has separate points for this year's actual count through today
+and its December 31 projection, connected by a dashed segment.
+These are server-rendered SVGs with CSS tooltips and no charting dependency.
 
 `bin/ci` writes JUnit results to `tmp/test-results/rspec.xml`. Failed system tests
 save screenshots under `tmp/screenshots/`; CircleCI retains both. CircleCI deploys

--- a/app/assets/stylesheets/admin_statistics.scss
+++ b/app/assets/stylesheets/admin_statistics.scss
@@ -1,0 +1,69 @@
+$sparkline-blue: #0063dc;
+
+.admin-stat-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 16px;
+  margin-bottom: 8px;
+}
+
+.admin-stat-label {
+  flex: 0 1 360px;
+}
+
+.admin-sparkline {
+  position: relative;
+  flex: 0 0 160px;
+  width: 160px;
+  height: 20px;
+
+  svg {
+    display: block;
+    fill: none;
+    stroke: $sparkline-blue;
+    stroke-width: 1.25;
+    stroke-linejoin: round;
+  }
+
+  circle.sparkline-actual { fill: $sparkline-blue; }
+  .sparkline-endpoint { fill: white; }
+  .sparkline-projection { stroke-dasharray: 3 3; }
+
+  .sparkline-hit-area {
+    position: absolute;
+    top: -4px;
+    height: 28px;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    cursor: crosshair;
+
+    &:hover, &:focus {
+      outline: 1px solid rgba($sparkline-blue, .45);
+      background: rgba($sparkline-blue, .08);
+    }
+  }
+
+  .sparkline-tooltip {
+    position: absolute;
+    z-index: 10;
+    bottom: 28px;
+    left: 0;
+    width: max-content;
+    max-width: 250px;
+    padding: 5px 8px;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    background: white;
+    color: #222;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, .1);
+    font-size: 12px;
+    line-height: 1.4;
+    visibility: hidden;
+  }
+
+  .sparkline-point:hover .sparkline-tooltip,
+  .sparkline-point:focus-within .sparkline-tooltip { visibility: visible; }
+}

--- a/app/helpers/admin/events_helper.rb
+++ b/app/helpers/admin/events_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Admin::EventsHelper
+  def sparkline_points(series)
+    maximum = [series.map { |point| point[:projected_count] || point[:count] }.max, 1].max
+    series.each_with_index.map do |point, index|
+      # Leave space for the endpoint dots inside the 160 × 20 SVG.
+      x = 2 + index * 156.0 / [series.size - 1, 1].max
+      value = point[:projected_count] || point[:count]
+      y = 18 - value * 16.0 / maximum
+      point.merge(x: x.round(2), y: y.round(2))
+    end
+  end
+
+  def sparkline_coordinates(points)
+    points.map { |point| "#{point[:x]},#{point[:y]}" }.join(' ')
+  end
+
+  def sparkline_tooltip(point)
+    label = "#{point[:label]}: "
+    if point.key?(:projected_count)
+      label += "#{number_with_delimiter(point[:count])} so far; " if point.key?(:count)
+      label + "#{number_with_delimiter(point[:projected_count])} extrapolated"
+    else
+      label + number_with_delimiter(point[:count])
+    end
+  end
+
+  def sparkline_hit_area(points, index)
+    left = index.zero? ? 0 : (points[index - 1][:x] + points[index][:x]) / 2.0
+    right = index == points.size - 1 ? 160 : (points[index][:x] + points[index + 1][:x]) / 2.0
+    "left: #{left / 1.6}%; width: #{(right - left) / 1.6}%"
+  end
+end

--- a/app/presenters/admin/event_stats.rb
+++ b/app/presenters/admin/event_stats.rb
@@ -7,7 +7,7 @@ module Admin
   class EventStats
     include ActionView::Helpers::NumberHelper
 
-    DEFAULT_MONTHS_BACK = 6
+    DEFAULT_MONTHS_BACK = 12
 
     attr_reader :events, :now, :months_back
 
@@ -24,10 +24,21 @@ module Admin
       number_with_delimiter(events.size)
     end
 
+    def oldest_creation_date
+      events.map(&:created_at).min&.strftime('%B %-d, %Y')
+    end
+
+    def current_year_count
+      number_with_delimiter(creation_counts_by_year.fetch(now.year, 0))
+    end
+
+    def extrapolated_current_year_count
+      number_with_delimiter(yearly_chart.last[:projected_count])
+    end
+
     # Example: {2022=>"12", 2023=>"44"}
     def yearly_counts
-      years = events.group_by { |e| e.created_at.year }
-      years.sort.reverse.map { |year, evts| [year, number_with_delimiter(evts.size)] }.to_h
+      creation_counts_by_year.sort.reverse.map { |year, count| [year, number_with_delimiter(count)] }.to_h
     end
 
     # Example: "2022: 12, 2023: 44"
@@ -58,17 +69,58 @@ module Admin
 
     # Example: "15"
     def extrapolated_current_month_count
-      current_month_start = (now).beginning_of_month
-      days_in_month = current_month_start.end_of_month.day.to_f
-      days_so_far = now.day.to_f
+      number_with_delimiter(monthly_projection)
+    end
 
-      return current_month_count if days_so_far.zero?
+    def yearly_chart
+      return @yearly_chart if @yearly_chart
 
-      extrapolated = (monthly_counts.first.last.to_f / days_so_far * days_in_month).round
-      number_with_delimiter(extrapolated)
+      counts = creation_counts_by_year
+      first_year = [counts.keys.min || now.year, now.year - 1].min
+      actual = (first_year..now.year).map do |year|
+        label = year == now.year ? "#{year} through #{now.strftime('%B %-d')}" : year.to_s
+        { label: label, count: counts.fetch(year, 0) }
+      end
+      projection = (actual.last[:count].to_f / now.yday * now.end_of_year.yday).round
+      @yearly_chart = actual + [{ label: "#{now.year} through December 31", projected_count: projection }]
+    end
+
+    def monthly_chart
+      monthly_counts.reverse.map do |month, count|
+        point = { label: month.strftime('%B %Y'), count: count }
+        point[:projected_count] = monthly_projection if month == now.beginning_of_month
+        point
+      end
+    end
+
+    # Running totals make the last observed day and the month-end forecast
+    # comparable to the monthly count shown beside this chart.
+    def current_month_chart
+      daily_counts = events.select do |event|
+        event.created_at >= now.beginning_of_month && event.created_at < now.beginning_of_month + 1.month
+      end.group_by { |event| event.created_at.day }.transform_values(&:size)
+      total = 0
+      (1..now.end_of_month.day).map do |day|
+        point = { label: "#{now.strftime('%B')} #{day}" }
+        if day <= now.day
+          total += daily_counts.fetch(day, 0)
+          point[:count] = total
+        else
+          point[:projected_count] = (total.to_f / now.day * day).round
+        end
+        point
+      end
     end
 
     private
+
+    def creation_counts_by_year
+      @creation_counts_by_year ||= events.group_by { |event| event.created_at.year }.transform_values(&:size)
+    end
+
+    def monthly_projection
+      (monthly_counts.first.last.to_f / now.day * now.end_of_month.day).round
+    end
 
     def monthly_counts
       @monthly_counts ||= (0..months_back).map do |offset|

--- a/app/views/admin/events/_sparkline.html.erb
+++ b/app/views/admin/events/_sparkline.html.erb
@@ -1,0 +1,24 @@
+<% points = sparkline_points(series) %>
+<% forecast_start = points.index { |point| point.key?(:projected_count) } %>
+<% actual = forecast_start ? points.take(forecast_start) : points %>
+<% forecast = forecast_start ? points.drop([forecast_start - 1, 0].max) : [] %>
+<div class="admin-sparkline" id="<%= id %>" role="group" aria-label="<%= label %>">
+  <svg width="160" height="20" viewBox="0 0 160 20" aria-hidden="true" focusable="false">
+    <% if actual.any? %>
+      <polyline class="sparkline-actual" points="<%= sparkline_coordinates(actual) %>" />
+      <circle class="sparkline-actual" cx="<%= actual.last[:x] %>" cy="<%= actual.last[:y] %>" r="1.5" />
+    <% end %>
+    <% if forecast.any? %>
+      <polyline class="sparkline-projection" points="<%= sparkline_coordinates(forecast) %>" />
+      <circle class="sparkline-endpoint" cx="<%= forecast.last[:x] %>" cy="<%= forecast.last[:y] %>" r="1.5" />
+    <% end %>
+  </svg>
+  <% points.each_with_index do |point, index| %>
+    <% tooltip = sparkline_tooltip(point) %>
+    <span class="sparkline-point">
+      <button type="button" class="sparkline-hit-area" style="<%= sparkline_hit_area(points, index) %>"
+              aria-label="<%= tooltip %>" aria-describedby="<%= id %>-point-<%= index %>"></button>
+      <span role="tooltip" class="sparkline-tooltip" id="<%= id %>-point-<%= index %>"><%= tooltip %></span>
+    </span>
+  <% end %>
+</div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,15 +1,18 @@
-<div class="mb-3">
-  <div>
-    <strong>Total events created:</strong> <%= @event_stats.total_events %>
-    (<%= @event_stats.yearly_counts_display %>)
+<div class="admin-statistics mb-3">
+  <div class="mb-2">
+    <strong>Total events created<% if (oldest_date = @event_stats.oldest_creation_date) %> since <%= oldest_date %><% end %>:</strong> <%= @event_stats.total_events %>
   </div>
-  <div>
-    <strong>Last <%= @event_stats.months_back %> full months (events created):</strong> <%= @event_stats.full_months_display %>
+  <div class="admin-stat-row">
+    <span class="admin-stat-label">Yearly <%= @event_stats.now.year %>: <strong><%= @event_stats.current_year_count %> so far</strong>, <%= @event_stats.extrapolated_current_year_count %> extrapolated</span>
+    <%= render 'sparkline', id: 'yearly-chart', label: 'Events created by year', series: @event_stats.yearly_chart %>
   </div>
-  <div>
-    <strong>This month (<%= @event_stats.current_month_label %>) — events created:</strong>
-    <%= @event_stats.current_month_count %> so far,
-    extrapolated: <%= @event_stats.extrapolated_current_month_count %>
+  <div class="admin-stat-row">
+    <span class="admin-stat-label">Last <%= @event_stats.months_back %> months</span>
+    <%= render 'sparkline', id: 'monthly-chart', label: 'Events created by month', series: @event_stats.monthly_chart %>
+  </div>
+  <div class="admin-stat-row">
+    <span class="admin-stat-label"><%= @event_stats.current_month_label %>: <strong><%= @event_stats.current_month_count %> so far</strong>, <%= @event_stats.extrapolated_current_month_count %> extrapolated</span>
+    <%= render 'sparkline', id: 'current-month-chart', label: 'Running total of events created this month', series: @event_stats.current_month_chart %>
   </div>
 </div>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,9 @@ Rails.application.configure do
   # Enable server timing.
   config.server_timing = true
 
+  # Local CI precompiles assets; always resolve current source while developing.
+  config.assets.resolve_with = [:environment]
+
   # Enable/disable Action Controller caching. By default Action Controller caching is disabled.
   # Run rails dev:cache to toggle Action Controller caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -8,7 +8,7 @@ describe 'admin dashboard stats', type: :feature do
     Event.create!(title: "Mid Event", date: Date.new(2022, 7, 15), created_at: Date.new(2022, 7, 15))
     Event.create!(title: "Recent Event", date: Date.new(Date.today.year, 1, 20), created_at: Date.new(Date.today.year, 1, 20))
     Event.create!(title: "This Month Event", date: Date.today.beginning_of_month + 2.days, created_at: Date.today.beginning_of_month + 2.days)
-    Event.create!(title: "Another This Month", date: Date.today.beginning_of_month + 10.days, created_at: Date.today.beginning_of_month + 10.days)
+    Event.create!(title: "Another This Month", date: Date.today.beginning_of_month + 10.days, created_at: Date.today.beginning_of_month + 6.days)
     Event.create!(title: "Last Month Event", date: (Date.today.beginning_of_month - 1.month) + 5.days, created_at: (Date.today.beginning_of_month - 1.month) + 5.days)
   end
 
@@ -19,19 +19,21 @@ describe 'admin dashboard stats', type: :feature do
     visit '/admin/events'
 
     # Total events
-    expect(page).to have_content("Total events created:")
+    expect(page).to have_content("Total events created since May 10, 2021: 6")
     expect(page).to have_content("2021: 1")
     expect(page).to have_content("2022: 1")
     expect(page).to have_content("#{Date.today.year}: 4")
 
-    # Last N full months (default 6)
-    expect(page).to have_content("full months")
+    # Last 12 completed months plus the current projection
+    expect(page).to have_content("Last 12 months")
     expect(page).to have_content(Date.today.strftime("%B %Y"))
     expect(page).to have_content((Date.today - 1.month).strftime("%B %Y"))
 
     # This month extrapolation
-    expect(page).to have_content("This month")
+    expect(page).to have_content("September 2026: 2 so far, 8 extrapolated")
     expect(page).to have_content("so far")
     expect(page).to have_content("extrapolated")
+    expect(page).to have_css('#monthly-chart button[aria-label="September 2026: 2 so far; 8 extrapolated"]')
+    expect(page).to have_css('#current-month-chart button[aria-label="September 30: 8 extrapolated"]')
   end
 end

--- a/spec/helpers/admin/events_helper_spec.rb
+++ b/spec/helpers/admin/events_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Admin::EventsHelper, type: :helper do
+  it 'uses one scale for actual and projected values and keeps dots inside the chart' do
+    points = helper.sparkline_points([
+      { label: '2025', count: 5 }, { label: '2026', count: 2, projected_count: 10 }
+    ])
+    expect(points.map { |point| [point[:x], point[:y]] }).to eq([[2, 10], [158, 2]])
+  end
+
+  it 'draws an empty history on a finite zero baseline' do
+    points = helper.sparkline_points([{ label: '2025', count: 0 }, { label: '2026', count: 0, projected_count: 0 }])
+    expect(helper.sparkline_coordinates(points)).to eq('2.0,18.0 158.0,18.0')
+  end
+
+  it 'formats large tooltip values and distinguishes estimates from actual counts' do
+    expect(helper.sparkline_tooltip(label: '2026', count: 1234, projected_count: 3702)).to eq('2026: 1,234 so far; 3,702 extrapolated')
+    expect(helper.sparkline_tooltip(label: 'September 30', projected_count: 3702)).to eq('September 30: 3,702 extrapolated')
+  end
+end

--- a/spec/lib/development_assets_spec.rb
+++ b/spec/lib/development_assets_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'open3'
+require 'json'
+
+RSpec.describe 'Development asset delivery' do
+  it 'serves current chart styles even when a precompiled manifest points to an older stylesheet' do
+    # Boot the actual development configuration: test deliberately bypasses the
+    # manifest, so ordinary browser specs cannot reproduce this failure.
+    script = <<~'RUBY'
+      require_relative 'config/environment'
+      require 'rack/mock'
+      Rails.application.assets_manifest.assets['application.css'] = 'application-stale.css'
+      path = ApplicationController.helpers.stylesheet_path('application')
+      response = Rack::MockRequest.new(Rails.application.assets).get(path.delete_prefix('/assets'))
+      puts JSON.generate(path: path, status: response.status,
+                         chart_styles: response.body.include?('.admin-sparkline'))
+    RUBY
+    stdout, stderr, status = Open3.capture3(
+      { 'RAILS_ENV' => 'development', 'AWS_EC2_METADATA_DISABLED' => 'true', 'SCOUT_MONITOR' => 'false' },
+      'bundle', 'exec', 'ruby', '-e', script, chdir: File.expand_path('../..', __dir__)
+    )
+    expect(status.success?).to be(true), stderr
+    result = JSON.parse(stdout.lines.last)
+    expect(result['path']).not_to include('application-stale.css')
+    expect(result['status']).to eq(200)
+    expect(result['chart_styles']).to be(true)
+  end
+end

--- a/spec/presenters/admin/event_stats_spec.rb
+++ b/spec/presenters/admin/event_stats_spec.rb
@@ -13,6 +13,23 @@ RSpec.describe Admin::EventStats do
     expect(stats.yearly_counts).to eq({})
     expect(stats.current_month_count).to eq('0')
     expect(stats.extrapolated_current_month_count).to eq('0')
+    expect(stats.oldest_creation_date).to be_nil
+    expect(stats.current_year_count).to eq('0')
+    expect(stats.extrapolated_current_year_count).to eq('0')
+  end
+
+  it 'labels the first creation date regardless of event order or scheduled dates' do
+    rows = [entry(date: Date.new(2010, 1, 1), created_at: Time.zone.local(2025, 9, 8)),
+            entry(date: Date.new(2030, 1, 1), created_at: Time.zone.local(2018, 2, 3))]
+    expect(described_class.new(rows, now: now).oldest_creation_date).to eq('February 3, 2018')
+  end
+
+  it 'formats the current year count and projection from the same data as its chart' do
+    rows = Array.new(1234) { entry(date: Date.new(2030, 1, 1), created_at: now) }
+    rows << entry(date: Date.new(2030, 1, 1), created_at: Time.zone.local(2025, 1, 1))
+    stats = described_class.new(rows, now: now)
+    expect(stats.current_year_count).to eq('1,234')
+    expect(stats.extrapolated_current_year_count).to eq('1,780')
   end
 
   it 'formats totals with thousands separators' do
@@ -105,6 +122,78 @@ RSpec.describe Admin::EventStats do
       end
       rows << entry(date: Date.new(2026, 9, 25), created_at: Time.zone.local(2026, 8, 20))
       expect(described_class.new(rows, now: now).extrapolated_current_month_count).to eq('15')
+    end
+  end
+
+  describe 'chart series' do
+    it 'orders years chronologically, fills gaps, and projects only the current year' do
+      rows = [entry(date: Date.new(2030, 1, 1), created_at: Time.zone.local(2024, 2, 1)),
+              entry(date: Date.new(2030, 1, 1), created_at: Time.zone.local(2026, 2, 1))]
+      stats = described_class.new(rows, now: Time.zone.local(2026, 7, 1))
+      expect(stats.yearly_chart).to eq([
+        { label: '2024', count: 1 }, { label: '2025', count: 0 },
+        { label: '2026 through July 1', count: 1 },
+        { label: '2026 through December 31', projected_count: 2 }
+      ])
+    end
+
+    it 'adds the current month projection after the completed monthly history' do
+      rows = Array.new(5) { entry(date: Date.new(2030, 1, 1), created_at: Time.zone.local(2026, 9, 2)) }
+      stats = described_class.new(rows, now: now, months_back: 2)
+      expect(stats.monthly_chart).to eq([
+        { label: 'July 2026', count: 0 }, { label: 'August 2026', count: 0 },
+        { label: 'September 2026', count: 5, projected_count: 15 }
+      ])
+    end
+
+    it 'keeps large projections numeric and shares the displayed monthly estimate' do
+      stats = described_class.new(Array.new(1234) { entry(date: Date.new(2026, 9, 2)) }, now: now)
+      expect(stats.monthly_chart.last[:projected_count]).to eq(3702)
+      expect(stats.extrapolated_current_month_count).to eq('3,702')
+    end
+
+    it 'renders a zero baseline and forecast for an empty database' do
+      stats = described_class.new([], now: now)
+      expect(stats.yearly_chart).to eq([
+        { label: '2025', count: 0 }, { label: '2026 through September 10', count: 0 },
+        { label: '2026 through December 31', projected_count: 0 }
+      ])
+      expect(stats.monthly_chart.size).to eq(13)
+      expect(stats.monthly_chart.first[:label]).to eq('September 2025')
+      expect(stats.monthly_chart.last[:projected_count]).to eq(0)
+    end
+
+    it 'uses all 366 days when projecting a leap year' do
+      stats = described_class.new([entry(date: Date.new(2024, 1, 1))], now: Time.zone.local(2024, 1, 1))
+      expect(stats.yearly_chart.last[:projected_count]).to eq(366)
+    end
+
+    it 'shows cumulative daily creations through today, then a month-end forecast' do
+      rows = [entry(date: Date.new(2030, 1, 1), created_at: Time.zone.local(2026, 9, 1)),
+              entry(date: Date.new(2030, 1, 1), created_at: Time.zone.local(2026, 9, 3)),
+              entry(date: Date.new(2030, 1, 1), created_at: Time.zone.local(2026, 8, 31))]
+      stats = described_class.new(rows, now: Time.zone.local(2026, 9, 4))
+      expect(stats.current_month_chart.first(4)).to eq([
+        { label: 'September 1', count: 1 }, { label: 'September 2', count: 1 },
+        { label: 'September 3', count: 2 }, { label: 'September 4', count: 2 }
+      ])
+      expect(stats.current_month_chart[4]).to eq(label: 'September 5', projected_count: 3)
+      expect(stats.current_month_chart.last).to eq(label: 'September 30', projected_count: 15)
+      expect(stats.current_month_chart.size).to eq(30)
+    end
+
+    it 'has no future forecast on the last day of a leap-year February' do
+      stats = described_class.new([entry(date: Date.new(2024, 2, 29))], now: Time.zone.local(2024, 2, 29))
+      expect(stats.current_month_chart.size).to eq(29)
+      expect(stats.current_month_chart.last).to eq(label: 'February 29', count: 1)
+      expect(stats.current_month_chart).to all(satisfy { |point| !point.key?(:projected_count) })
+    end
+
+    it 'handles the first day of a month and keeps all charts query-free' do
+      stats = described_class.new([], now: Time.zone.local(2026, 1, 1))
+      expect(count_queries { stats.yearly_chart; stats.monthly_chart; stats.current_month_chart }).to eq(0)
+      expect(stats.current_month_chart.first).to eq(label: 'January 1', count: 0)
+      expect(stats.current_month_chart.last).to eq(label: 'January 31', projected_count: 0)
     end
   end
 

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -49,8 +49,33 @@ RSpec.describe 'Site administrator dashboard', type: :request do
     create(:event, date: Date.new(2026, 9, 20), created_at: Time.zone.local(2026, 8, 2))
     get admin_events_path, headers: dashboard_headers
     text = Nokogiri::HTML(response.body).text.squish
-    expect(text).to include('Total events created: 3', 'August 2026: 1')
-    expect(text).to include('This month (September 2026) — events created: 2 so far, extrapolated: 6')
+    expect(text).to include('Total events created since August 2, 2026: 3', 'August 2026: 1')
+    expect(text).to include('September 2026: 2 so far, 6 extrapolated')
+    expect(text).to include('September 2026: 2 so far; 6 extrapolated')
+  end
+
+  it 'renders three compact charts with actual values and distinct forecasts' do
+    travel_to Time.zone.local(2026, 9, 10, 12) do
+      create(:event, created_at: Time.zone.local(2025, 1, 1))
+      create_list(:event, 2, created_at: Time.zone.local(2026, 9, 1))
+      get admin_events_path, headers: dashboard_headers
+      doc = Nokogiri::HTML(response.body)
+      expect(doc.css('.admin-sparkline svg[height="20"]').size).to eq(3)
+      expect(doc.css('.admin-sparkline .sparkline-projection').size).to eq(3)
+      expect(doc.css('.admin-sparkline polyline.sparkline-actual').size).to eq(3)
+      expect(doc.css('#monthly-chart button').last['aria-label']).to eq('September 2026: 2 so far; 6 extrapolated')
+      expect(doc.css('#current-month-chart button').last['aria-label']).to eq('September 30: 6 extrapolated')
+      expect(doc.css('#yearly-chart button').first['aria-label']).to eq('2025: 1')
+      expect(doc.css('#yearly-chart button')[-2]['aria-label']).to eq('2026 through September 10: 2')
+      expect(doc.css('#yearly-chart button').last['aria-label']).to eq('2026 through December 31: 3 extrapolated')
+      actual_points = doc.at_css('#yearly-chart polyline.sparkline-actual')['points'].split
+      forecast_points = doc.at_css('#yearly-chart polyline.sparkline-projection')['points'].split
+      expect(actual_points.size).to eq(2)
+      expect(forecast_points.size).to eq(2)
+      expect(forecast_points.first).to eq(actual_points.last)
+      expect(forecast_points.last).not_to eq(actual_points.last)
+      expect(doc.css('.admin-statistics').text).not_to match(/NaN|Infinity/)
+    end
   end
 
 end

--- a/spec/system/admin_charts_spec.rb
+++ b/spec/system/admin_charts_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe 'Administrator charts', type: :system, js: true do
+  def visit_dashboard
+    visit "http://spec-admin:spec-password@#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}/admin/events"
+  end
+
+  it 'shows actual and projected numbers on hover and keyboard focus, including after navigation' do
+    travel_to Time.zone.local(2026, 9, 10, 12) do
+      create(:event, title: 'Chart example', created_at: Time.zone.local(2025, 1, 1))
+      create_list(:event, 2, created_at: Time.zone.local(2026, 9, 2))
+      visit_dashboard
+      expect(page).to have_content('Total events created since January 1, 2025: 3')
+      expect(page).to have_content('September 2026: 2 so far, 6 extrapolated')
+
+      expect(page).to have_content('2026: 2 so far, 3 extrapolated')
+      expect(page).to have_content('Last 12 months')
+      expect(page).to have_no_content('Solid: actual')
+
+      within('#yearly-chart') do
+        find('button', match: :first).hover
+        expect(page).to have_css('[role="tooltip"]', text: '2025: 1', visible: true)
+        all('button')[-2].hover
+        expect(page).to have_css('[role="tooltip"]', text: '2026 through September 10: 2', visible: true)
+        all('button').last.hover
+        expect(page).to have_css('[role="tooltip"]', text: '2026 through December 31: 3 extrapolated', visible: true)
+      end
+      within('#monthly-chart') do
+        all('button').last.hover
+        expect(page).to have_css('[role="tooltip"]', text: 'September 2026: 2 so far; 6 extrapolated', visible: true)
+      end
+      within('#current-month-chart') do
+        find('button[aria-label="September 10: 2"]').hover
+        expect(page).to have_css('[role="tooltip"]', text: 'September 10: 2', visible: true)
+        # Tab between adjacent days verifies the keyboard path without a mouse hover.
+        all('button')[-2].click
+        send_keys :tab
+        expect(page).to have_css('[role="tooltip"]', text: 'September 30: 6 extrapolated', visible: true)
+      end
+      expect(find('#monthly-chart .sparkline-projection').evaluate_script('getComputedStyle(this).strokeDasharray')).not_to eq('none')
+
+      click_link 'Sort by RSVP count'
+      within('#monthly-chart') do
+        all('button').last.hover
+        expect(page).to have_css('[role="tooltip"]', text: 'September 2026: 2 so far; 6 extrapolated', visible: true)
+      end
+      FileUtils.mkdir_p(Capybara.save_path)
+      find('.admin-statistics').native.save_screenshot(Rails.root.join('tmp/screenshots/admin-charts-desktop.png'))
+      page.current_window.resize_to(390, 844)
+      find('#current-month-chart button', match: :first).click
+      expect(page).to have_css('#current-month-chart [role="tooltip"]', text: 'September 1: 0', visible: true)
+      expect(find('.admin-statistics').evaluate_script('this.scrollWidth <= this.clientWidth')).to be(true)
+      find('.admin-statistics').native.save_screenshot(Rails.root.join('tmp/screenshots/admin-charts-mobile.png'))
+    end
+  end
+
+  it 'renders empty charts without broken coordinates or hover values' do
+    visit_dashboard
+    expect(page).to have_css('.admin-sparkline svg', count: 3)
+    within('#monthly-chart') do
+      all('button').last.hover
+      expect(page).to have_css('[role="tooltip"]', text: '0 so far; 0 extrapolated', visible: true)
+    end
+    expect(page).to have_no_css('polyline[points*="NaN"], polyline[points*="Infinity"]')
+  end
+end


### PR DESCRIPTION
Replace the admin dashboard’s text-only history with compact blue charts while keeping totals and current-period estimates visible.

- Show the all-time total with the earliest event creation date, yearly history, the last 12 completed months plus the current projection, and this month’s running daily total.
- Draw actual counts with solid lines and projections with dashes. The yearly chart includes separate points for this year’s count through today and its December 31 estimate.
- Show counts on hover and keyboard focus using server-rendered SVG and CSS, with no charting dependency. Keep the yearly and monthly summaries to the left of their charts.
- Resolve current assets in development so local precompilation cannot leave the charts unstyled.

Validation: `CI=true bin/ci` passes Rails eager loading, asset compilation, and all 194 examples with no failures or pending tests. Coverage includes projections, missing periods, leap years, SVG scaling, Firefox hover/keyboard behavior, narrow layouts, navigation, and stale development assets.

No migrations or new dependencies.
