### PR TITLE
Redact organizer tokens from application logs and Rollbar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,3 +138,7 @@ Sprockets compiles assets. The Node buildpack runs before the Ruby buildpack in
 `.buildpacks`; keep that order. `bin/ci` installs and audits the locked npm graph,
 builds Trix with the pinned DOMPurify version, and then compiles assets. Node 24
 is selected by `.node-version` locally and `package.json` during buildpack deploys.
+
+Application log formatters and Rollbar transforms redact organizer URL segments
+and UUID-shaped credentials. See `docs/ORGANIZER_LOG_PRIVACY.md` for proxy rollout;
+application redaction alone does not establish production proxy/log-collector privacy.

--- a/README.md
+++ b/README.md
@@ -172,3 +172,6 @@ Dokku uses the pinned Node and Ruby buildpacks in `.buildpacks`, in that order.
 The Node buildpack runs `npm ci` and `npm run build`; the Ruby buildpack then
 compiles the generated files with the rest of the Rails assets. `BUILDPACK_URL`
 must not be set for the app because it overrides the ordered buildpack list.
+
+Organizer URL logging and proxy rollout are covered in
+[Organizer link privacy](docs/ORGANIZER_LOG_PRIVACY.md).

--- a/config/initializers/organizer_log_privacy.rb
+++ b/config/initializers/organizer_log_privacy.rb
@@ -1,0 +1,15 @@
+require Rails.root.join('lib/organizer_token_redactor')
+
+Rails.application.config.after_initialize do
+  loggers = Rails.logger.respond_to?(:broadcasts) ? Rails.logger.broadcasts : [Rails.logger]
+  loggers.each do |logger|
+    logger.formatter = OrganizerTokenRedactor::Formatter.new(logger.formatter || Logger::Formatter.new)
+  end
+end
+
+Rollbar.configure do |config|
+  config.scrub_fields |= [:admin_token]
+  config.transform << lambda do |payload|
+    payload.replace(OrganizerTokenRedactor.scrub(payload))
+  end
+end

--- a/config/nginx/organizer-log-format.conf
+++ b/config/nginx/organizer-log-format.conf
@@ -1,0 +1,8 @@
+# Include in nginx's http context, then select organizer_private in the site's
+# access_log directive. $uri is normalized and excludes the query string.
+map $uri $organizer_private_uri {
+    default $uri;
+    ~^/[^/]+/admin/ /[FILTERED]/admin/[FILTERED];
+}
+log_format organizer_private '$remote_addr $request_method $organizer_private_uri '
+                             '$status $body_bytes_sent $request_time';

--- a/docs/CODEBASE_ASSESSMENT.md
+++ b/docs/CODEBASE_ASSESSMENT.md
@@ -447,7 +447,10 @@ provided; Bon App's accepted risks do not transfer.
   2.0.0 too; no specific clipboard vulnerability was established here. Empty npm
   dependencies mean npm/Dependabot cannot track these checked-in JS copies.
 
-- [ ] **2.3 P1 — Keep organizer credentials out of URL logs.**
+- [ ] **2.3 P1 — Keep organizer credentials out of URL logs.** Application
+  logger and Rollbar redaction are implemented with 200 passing tests. Proxy
+  rollout and external collector verification remain; see
+  [Organizer link privacy](ORGANIZER_LOG_PRIVACY.md). Original finding:
   Routes embed the credential in the path (`config/routes.rb:4`), and Rails'
   request-start log includes that path verbatim. A local logger probe found the
   synthetic token even though parameter filtering includes `:token`. Redact these

--- a/docs/ORGANIZER_LOG_PRIVACY.md
+++ b/docs/ORGANIZER_LOG_PRIVACY.md
@@ -1,0 +1,24 @@
+# Organizer link privacy
+
+Organizer links are bearer credentials. The application logger filters organizer
+path segments and UUID-shaped values before writing messages, including request
+starts, redirects, SQL diagnostics and tagged messages. Rollbar payloads receive
+the same recursive filtering; its `admin_token` field is also scrubbed. Public
+routes, authorization and shareable organizer links are unchanged.
+
+This does not rewrite old logs or configure the production proxy. During an
+explicitly authorized deployment, include `config/nginx/organizer-log-format.conf`
+in nginx's `http` context and select `organizer_private` in the site's `access_log`
+directive. Validate with `nginx -t` before reloading. Check every effective
+`access_log` destination, including Dokku-generated configuration; leaving a
+second default access log enabled retains the original exposure. The format
+omits query strings, referrers and user agents and masks organizer paths.
+
+Nginx error logs can also include full request URLs; route these through a
+redacting log processor before collection, or establish a proxy configuration
+that does not record raw request URLs. This repo cannot attest to external log
+collectors, APM configuration, or retention without deployment inspection.
+Use synthetic organizer links to verify each sink. Restrict and expire historical
+logs according to the operator's retention policy; do not copy real tokens into
+issues or test fixtures. No historical log deletion or token rotation is performed
+by this change.

--- a/lib/organizer_token_redactor.rb
+++ b/lib/organizer_token_redactor.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'delegate'
+
+module OrganizerTokenRedactor
+  UUID = /\b[0-9a-f]{8}(?:-|%2d)[0-9a-f]{4}(?:-|%2d)[0-9a-f]{4}(?:-|%2d)[0-9a-f]{4}(?:-|%2d)[0-9a-f]{12}\b/i
+  ORGANIZER_PATH = %r{(/[^/\s?\#]+/admin/)[^/\s?\#"<>]+}
+
+  def self.redact(value)
+    value.gsub(ORGANIZER_PATH, '\\1[FILTERED]').gsub(UUID, '[FILTERED]')
+  end
+
+  # Rollbar payloads include URLs in request metadata, frames and messages.
+  def self.scrub(value)
+    case value
+    when Hash then value.transform_values { |item| scrub(item) }
+    when Array then value.map { |item| scrub(item) }
+    when String then redact(value)
+    else value
+    end
+  end
+
+  class Formatter < SimpleDelegator
+    def call(*arguments)
+      OrganizerTokenRedactor.redact(__getobj__.call(*arguments))
+    end
+  end
+end

--- a/spec/lib/organizer_token_redactor_spec.rb
+++ b/spec/lib/organizer_token_redactor_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe OrganizerTokenRedactor do
+  let(:token) { SecureRandom.uuid }
+
+  it 'redacts paths, standalone SQL values, referers and encoded path segments' do
+    examples = ["Started GET /party/admin/#{token}/edit", "admin_token=#{token}",
+                "https://example.com/party/admin/#{token}?sort=recent", "/party/admin/#{token.gsub('-', '%2D')}/rsvps/1",
+                '/party/admin/%30%31%32%33/edit']
+    examples.each do |text|
+      expect(described_class.redact(text)).to include('[FILTERED]')
+      expect(described_class.redact(text).include?(token)).to be(false)
+    end
+    expect(described_class.redact('/admin/events?sort=rsvps')).to eq('/admin/events?sort=rsvps')
+    expect(described_class.redact('/party')).to eq('/party')
+  end
+
+  it 'scrubs nested Rollbar payloads without losing diagnostic metadata' do
+    payload = { 'data' => { 'request' => { 'url' => "https://example.com/party/admin/#{token}" },
+                           'body' => { 'message' => { 'body' => "Failed #{token}" } }, 'level' => 'error' } }
+    Rollbar.configuration.transform.each { |transform| transform.call(payload) }
+    expect(payload.to_s.include?(token)).to be(false)
+    expect(payload.dig('data', 'level')).to eq('error')
+  end
+
+  it 'preserves tagged logger behavior while filtering tags and messages' do
+    output = StringIO.new
+    logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(output))
+    logger.formatter = described_class::Formatter.new(logger.formatter)
+    logger.tagged(token) { logger.info("Organizer #{token}") }
+    expect(output.string.include?(token)).to be(false)
+    expect(output.string).to include('Organizer [FILTERED]')
+  end
+end

--- a/spec/requests/organizer_log_privacy_spec.rb
+++ b/spec/requests/organizer_log_privacy_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'stringio'
+
+RSpec.describe 'Organizer log privacy', type: :request do
+  it 'redacts organizer paths without changing authorization or redirects' do
+    event = create(:event)
+    output = StringIO.new
+    logger = ActiveSupport::Logger.new(output)
+    original = Rails.logger.respond_to?(:broadcasts) ? Rails.logger.broadcasts.first : Rails.logger
+    logger.formatter = original.formatter
+    allow(Rails).to receive(:logger).and_return(logger)
+    get event_admin_path(event, event.admin_token)
+    expect(response).to have_http_status(:ok)
+    expect(output.string).to include('Started GET')
+    expect(output.string.include?(event.admin_token)).to be(false)
+    expect(output.string).to include('[FILTERED]')
+    post toggle_publish_event_admin_path(event, event.admin_token)
+    expect(response).to redirect_to(event_admin_path(event, event.admin_token))
+    expect(event.reload.published?).to be(false)
+    expect(output.string.include?(event.admin_token)).to be(false)
+  end
+end


### PR DESCRIPTION
Keep organizer bearer credentials out of application logs and Rollbar payloads without changing links or authorization. Filter organizer URL segments and UUID-shaped values in log formatter output, including tags, and recursively scrub error reports.

Include an nginx access-log format and an explicit deployment checklist for proxy and collector coverage. Application code cannot configure existing external logs: proxy/error-log collection and historical retention still need an authorized operations review. No historical logs, production services or tokens are modified.

Validation: `CI=true bin/ci` passes eager loading, assets, and 200 tests. New tests reproduce a token in request-start logs before the fix and cover authorized navigation/redirects, nested Rollbar payloads, encoded paths, and tagged logging after it.

