### PR TITLE
Keep development uploads and email local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ Verified against the repository on 2026-09-08; the version files remain authorit
 | Database | PostgreSQL; `events_development`, `events_test`, `events_production` |
 | UI | ERB, Simple Form, Bootstrap 4.6.2.1 |
 | Assets | Sprockets, SassC, CoffeeScript, jQuery, Rails UJS, Turbolinks, Trix 2.1.19 built with npm/esbuild |
-| Storage | Active Storage; S3 in development/production, disk in test |
-| Mail | Action Mailer with SMTP; organizer-link delivery is synchronous |
+| Storage | Active Storage; disk in development/test, S3 in production |
+| Mail | Action Mailer; file delivery in development, test delivery in test, SMTP in production; organizer-link delivery is synchronous |
 | Tests | RSpec, FactoryBot, WebMock; Rack Test by default, Selenium/headless Firefox for `js: true` system specs |
 | CI/deploy | CircleCI; Dokku app `easy-rsvp`, server configured through `DOKKU_HOST` |
 
@@ -119,9 +119,10 @@ Do not add pending markers for new failures without reproducing and documenting
 the defect. Regression expectations must continue to execute after fixes. No application services exist under `app/services` today; the
 production-database utility and command runner are unit-tested under `spec/lib`.
 
-`bin/dev` runs the Rails server. Development uploads use the configured S3 bucket
-and organizer-link requests can send real SMTP email. Ordinary tests use local
-storage and test delivery. Do not exercise external side effects without the
+`bin/dev` runs the Rails server. Development uploads and imported `amazon` blobs resolve to local disk under
+`storage/development`; organizer-link emails are written to `tmp/mail`. Imported
+images require a separately authorized local file copy; no remote fallback exists.
+Ordinary tests use local storage and test delivery. Do not exercise external side effects without the
 user's authorization.
 
 `db:pull_production` exports production over SSH and replaces only local

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ bin/dev
 
 Configure the environment values needed by the flows you use. The dashboard
 uses `ADMIN_USER` and `ADMIN_PASSWORD`. Organizer-link emails use the `SMTP_*`
-settings and `DOMAIN`. Development uploads currently use the S3 service in
-`config/storage.yml`, so uploading or deleting attachments can affect real
-storage; organizer-link requests can send real email.
+settings and `DOMAIN`. Development uploads use `storage/development`, and organizer-link emails are
+written under `tmp/mail` for local inspection. No SMTP or S3 credentials are
+needed for those development flows.
 
 ## Tests
 
@@ -138,8 +138,11 @@ and archive mode `0600`. Keep the previous local archive until the import is
 verified, then delete unneeded copies containing real user data.
 
 After importing, apply any pending local migrations with `bin/rails db:migrate`.
-This task copies database rows only; it does not copy attachment files or isolate
-the app's configured S3 bucket and SMTP service.
+This task copies database rows only; it does not copy attachment files. In
+development, imported `amazon` blobs resolve to local disk, and email stays in
+`tmp/mail`. Imported images are unavailable until their files are copied into
+local storage through a separately authorized export. Never fall back to S3
+for missing local files. Unknown storage service names fail closed.
 
 The import tests use fake commands and never access Dokku or replace a database:
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,7 +32,14 @@ Rails.application.configure do
   config.cache_store = :memory_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
+  # Imported blobs retain service_name="amazon". Resolve that alias to disk too,
+  # so reads, uploads and purges in development never reach production S3.
+  local_storage = { service: "Disk", root: Rails.root.join("storage/development").to_s }
+  config.active_storage.service_configurations = { "local" => local_storage, "amazon" => local_storage }
+
+  config.action_mailer.delivery_method = :file
+  config.action_mailer.file_settings = { location: Rails.root.join("tmp/mail") }
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/docs/CODEBASE_ASSESSMENT.md
+++ b/docs/CODEBASE_ASSESSMENT.md
@@ -487,7 +487,12 @@ provided; Bon App's accepted risks do not transfer.
   introduced. The preceding documentation/import task is completed preparation,
   not evidence that the old product flows have been repaired.
 
-- [ ] **3.2 P1 — Isolate development storage and email.**
+- [x] **3.2 P1 — Isolate development storage and email.** Development uses a
+  dedicated disk root and file delivery under `tmp/mail`; imported `amazon` blobs
+  resolve to the same local disk service, preventing remote reads and purges. A
+  separate-environment regression proves external credentials and endpoints are
+  ignored. Existing imported files require an explicitly authorized local copy.
+  Original finding:
   `config/environments/development.rb:32` selects `:amazon`; production also uses
   that service, whose bucket is fixed in `config/storage.yml`. SMTP delivery is
   enabled in `config/application.rb`. The README now warns about these existing

--- a/spec/lib/development_isolation_spec.rb
+++ b/spec/lib/development_isolation_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'open3'
+require 'json'
+
+RSpec.describe 'Development storage and email isolation' do
+  it 'maps imported S3 blobs to disk and captures email locally even with external settings present' do
+    script = <<~'RUBY'
+      require 'webmock'
+      include WebMock::API
+      WebMock.enable!
+      WebMock.disable_net_connect!
+      require_relative 'config/environment'
+      require 'tmpdir'
+      services = %w[local amazon].map { |name| ActiveStorage::Blob.services.fetch(name).class.name }
+      method = ActionMailer::Base.delivery_method
+      files = []
+      if method == :file
+        Dir.mktmpdir do |directory|
+          ActionMailer::Base.file_settings = {location: directory}
+          LocalPreviewMailer = Class.new(ActionMailer::Base) do
+            def preview
+              mail(to: 'preview@example.test', from: 'app@example.test', subject: 'Local preview', body: 'Local only')
+            end
+          end
+          LocalPreviewMailer.preview.deliver_now
+          files = Dir.glob("#{directory}/*").map { |path| File.read(path).include?('Local only') }
+        end
+      end
+      puts JSON.generate(service: Rails.configuration.active_storage.service, services: services,
+                         delivery: method, captured: files)
+    RUBY
+    stdout, stderr, status = Open3.capture3(
+      {'RAILS_ENV' => 'development', 'SCOUT_MONITOR' => 'false', 'AWS_EC2_METADATA_DISABLED' => 'true',
+       'S3_ACCESS_KEY_ID' => 'synthetic', 'S3_SECRET_ACCESS_KEY' => 'synthetic', 'SMTP_SERVER' => 'smtp.example.test'},
+      'bundle', 'exec', 'ruby', '-e', script, chdir: File.expand_path('../..', __dir__)
+    )
+    expect(status.success?).to be(true), stderr
+    result = JSON.parse(stdout.lines.last)
+    expect(result).to eq('service' => 'local', 'services' => ['ActiveStorage::Service::DiskService'] * 2,
+                        'delivery' => 'file', 'captured' => [true])
+  end
+end


### PR DESCRIPTION
Make ordinary development safe after a production database import: store uploads under `storage/development`, write organizer-link emails to `tmp/mail`, and resolve imported blobs whose `service_name` is `amazon` to that same local disk service. Missing imported files fail locally instead of falling back to S3.

The production S3/SMTP configuration is unchanged. Existing attachment files are not copied; that remains a separately authorized operation.

Validation: `CI=true bin/ci` passes eager loading, asset compilation, and all 195 tests. A separate-process regression boots development with synthetic S3/SMTP settings, verifies both local and imported-service aliases use disk, and proves mail is captured locally without network access.
