### PR TITLE
Own and expire editor image uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,9 @@ eager-loading, asset-compilation, and RSpec checks.
   `RESPONSES = [:yes, :maybe, :no]`, with inclusion validation and a database check
   for new writes. Historical rows still need review before validating the constraint.
 - `ImageUpload`: one required PNG/JPEG/GIF/WebP image, at most 10 MB. The upload
-  endpoint detects MIME type from file bytes. Upload ownership remains independent
-  of event creation and needs a separate lifecycle design.
+  endpoint detects MIME type from file bytes and requires a per-editor capability.
+  Saved events claim only referenced uploads. Unclaimed managed uploads expire
+  after 24 hours; historical unowned rows are excluded from automated cleanup.
 - `EventsController`: event creation and public display.
 - `EventsAdminController`: organizer display, editing, deletion, publication.
 - `RsvpsController`: public response creation and session-owned deletion.
@@ -129,6 +130,10 @@ user's authorization.
 `events_development` after confirmation and a validated backup. Its usage and
 recovery files are documented in the [README](README.md). Adding or testing its
 code is separate from running an actual production import.
+
+Run `bin/rails image_uploads:purge_abandoned` from a production scheduler to
+remove managed uploads left unclaimed for 24 hours. The task refuses development
+execution because an imported database can still contain production blob records.
 
 Never commit, push, or deploy automatically. CircleCI deploys successful `main`
 builds, so a push to `main` has a production side effect.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,26 @@ All 19 original pending expectations now pass. Guest RSVP additions/deletions ar
 blocked on unpublished events while organizer editing remains available. Dashboard
 counts and projections use creation dates. Public image uploads require detected
 PNG/JPEG/GIF/WebP content and a maximum size of 10 MB; failed Trix uploads show an
-error and permit another attempt. Production email links require `DOMAIN` (a host
-without a URL scheme) and use HTTPS.
+error and permit another attempt. The editor issues a per-form upload capability,
+and saving an event assigns only the images still referenced in that editor. The
+unused Active Storage direct-upload endpoint returns 404. Upload requests with a
+declared content length have an 11 MB transport envelope and are limited to 20
+attempts per IP per minute using the configured Rails controller cache.
+Production email links require `DOMAIN` (a host without a URL scheme) and use
+HTTPS.
+
+Managed uploads that are not assigned to an event cannot be claimed after 24
+hours. Run the cleanup task from a production scheduler, preferably hourly:
+
+```sh
+bin/rails image_uploads:purge_abandoned
+```
+
+The task refuses to run in development because an imported database may still
+reference production storage. Historical unowned uploads have no capability
+digest and are deliberately excluded; review those rows separately before any
+backfill or deletion. Uploads assigned to an event are removed with that event,
+and Active Storage purges their blobs through its normal attachment lifecycle.
 
 The RSVP migration enforces supported response values on new writes using a
 PostgreSQL `NOT VALID` check constraint. It leaves historical records unchanged;

--- a/app/assets/javascripts/trix_attachments.js
+++ b/app/assets/javascripts/trix_attachments.js
@@ -6,6 +6,7 @@
   function uploadAttachment(attachment, editor) {
     var form = new FormData();
     form.append("image_upload[image]", attachment.file);
+    form.append("image_upload[token]", editor.dataset.uploadToken);
 
     var xhr = new XMLHttpRequest();
     xhr.open("POST", "/image_uploads", true);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  include ImageUploadSessions
 end

--- a/app/controllers/concerns/image_upload_sessions.rb
+++ b/app/controllers/concerns/image_upload_sessions.rb
@@ -1,0 +1,48 @@
+module ImageUploadSessions
+  extend ActiveSupport::Concern
+
+  MAXIMUM_OPEN_SESSIONS = 8
+  SESSION_KEY = :image_upload_session_digests
+
+  private
+
+  def prepare_image_upload_token
+    candidate = params[:image_upload_token]
+    @image_upload_token = if registered_image_upload_token?(candidate)
+      candidate
+    else
+      register_image_upload_token
+    end
+  end
+
+  def registered_image_upload_token?(candidate)
+    return false unless candidate.is_a?(String) && candidate.present?
+
+    digest = ImageUpload.digest_token(candidate)
+    Array(session[SESSION_KEY]).any? do |registered_digest|
+      registered_digest.bytesize == digest.bytesize &&
+        ActiveSupport::SecurityUtils.secure_compare(registered_digest, digest)
+    end
+  end
+
+  def register_image_upload_token
+    token = SecureRandom.urlsafe_base64(32)
+    digests = Array(session[SESSION_KEY]).last(MAXIMUM_OPEN_SESSIONS - 1)
+    session[SESSION_KEY] = digests << ImageUpload.digest_token(token)
+    token
+  end
+
+  def claim_image_uploads(event)
+    event.claim_image_uploads!(@image_upload_token)
+    retire_image_upload_token(@image_upload_token)
+  end
+
+  def retire_image_upload_token(token)
+    digest = ImageUpload.digest_token(token)
+    remaining = Array(session[SESSION_KEY]).reject do |registered_digest|
+      registered_digest.bytesize == digest.bytesize &&
+        ActiveSupport::SecurityUtils.secure_compare(registered_digest, digest)
+    end
+    remaining.empty? ? session.delete(SESSION_KEY) : session[SESSION_KEY] = remaining
+  end
+end

--- a/app/controllers/events_admin_controller.rb
+++ b/app/controllers/events_admin_controller.rb
@@ -1,5 +1,6 @@
 class EventsAdminController < ApplicationController
   before_action :set_event
+  before_action :prepare_image_upload_token, only: [:edit, :update]
 
   def show
     @rsvps = @event.rsvps.persisted.order(created_at: :asc)
@@ -10,6 +11,7 @@ class EventsAdminController < ApplicationController
 
   def update
     if @event.update(event_params)
+      claim_image_uploads(@event)
       redirect_to event_admin_path(@event, @event.admin_token), notice: 'Your event was updated.'
     else
       render :edit

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,7 @@
 class EventsController < ApplicationController
   before_action :set_event, only: [:show]
   before_action :set_placeholders, only: [:new]
+  before_action :prepare_image_upload_token, only: [:new, :create]
 
   def show
     @rsvp = @event.rsvps.new
@@ -18,6 +19,7 @@ class EventsController < ApplicationController
     @event = Event.new(event_params)
 
     if @event.save
+      claim_image_uploads(@event)
       redirect_to event_admin_path(@event, @event.admin_token)
     else
       set_placeholders

--- a/app/controllers/image_uploads_controller.rb
+++ b/app/controllers/image_uploads_controller.rb
@@ -1,13 +1,27 @@
 class ImageUploadsController < ApplicationController
+  rate_limit to: 20, within: 1.minute, only: :create, with: :upload_rate_limited
+
+  def direct_upload_disabled
+    head :not_found
+  end
+
   def create
     attributes = image_upload_params
+    upload_token = submitted_upload_token
+    unless registered_image_upload_token?(upload_token)
+      render json: { image: ["upload session is invalid or expired"] }, status: :forbidden
+      return
+    end
+
     file = attributes[:image]
     if file.present? && !file.is_a?(ActionDispatch::Http::UploadedFile)
       render json: { image: ["must be an uploaded image file"] }, status: :unprocessable_entity
       return
     end
 
-    @image_upload = ImageUpload.new(attributes)
+    @image_upload = ImageUpload.new(
+      attributes.merge(upload_session_digest: ImageUpload.digest_token(upload_token))
+    )
     if file.present?
       # Do not trust a client-supplied MIME type or filename extension.
       @image_upload.image.blob.content_type = Marcel::MimeType.for(file.tempfile)
@@ -24,7 +38,16 @@ class ImageUploadsController < ApplicationController
 
   private
 
+  def upload_rate_limited
+    render json: { image: ["too many uploads; please wait and try again"] }, status: :too_many_requests
+  end
+
   def image_upload_params
     params.require(:image_upload).permit(:image)
+  end
+
+  def submitted_upload_token
+    upload_params = params[:image_upload]
+    upload_params[:token] if upload_params.is_a?(ActionController::Parameters)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,7 @@ class Event < ApplicationRecord
   include Hashid::Rails
 
   has_many :rsvps, dependent: :destroy
+  has_many :image_uploads, dependent: :destroy
 
   before_create :set_admin_token
 
@@ -10,6 +11,22 @@ class Event < ApplicationRecord
 
   def to_param
     "#{hashid}-#{title.parameterize}"
+  end
+
+  def claim_image_uploads!(upload_token)
+    referenced_ids = ImageUpload.claimable_by(upload_token)
+      .includes(image_attachment: :blob)
+      .filter_map do |upload|
+        upload.id if body.to_s.include?(upload.image.blob.signed_id)
+      end
+
+    return 0 if referenced_ids.empty?
+
+    ImageUpload.where(id: referenced_ids, event_id: nil).update_all(
+      event_id: id,
+      upload_session_digest: nil,
+      updated_at: Time.current
+    )
   end
 
   private

--- a/app/models/image_upload.rb
+++ b/app/models/image_upload.rb
@@ -1,10 +1,36 @@
 class ImageUpload < ApplicationRecord
   CONTENT_TYPES = %w[image/png image/jpeg image/gif image/webp].freeze
   MAXIMUM_SIZE = 10.megabytes
+  ABANDONED_AFTER = 24.hours
 
+  belongs_to :event, optional: true
   has_one_attached :image
 
   validate :acceptable_image
+
+  scope :claimable_by, ->(token, at: Time.current) {
+    where(event_id: nil, upload_session_digest: digest_token(token))
+      .where(created_at: (at - ABANDONED_AFTER)..)
+  }
+  scope :abandoned, ->(at: Time.current) {
+    where(event_id: nil)
+      .where.not(upload_session_digest: nil)
+      .where(created_at: ...(at - ABANDONED_AFTER))
+  }
+
+  def self.digest_token(token)
+    Digest::SHA256.hexdigest(token.to_s)
+  end
+
+  def self.purge_abandoned!(at: Time.current)
+    count = 0
+    abandoned(at: at).find_each do |upload|
+      upload.image.purge
+      upload.destroy!
+      count += 1
+    end
+    count
+  end
 
   private
 

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -5,6 +5,7 @@
 <br>
 
 <%= simple_form_for @event do |f| %>
+  <%= hidden_field_tag :image_upload_token, @image_upload_token %>
   <%= f.input :title, required: false, label: 'What are you planning?', placeholder: @placeholders[:title] %>
 
   <%= f.input :date,
@@ -18,7 +19,7 @@
 
   <%= f.label :body, 'More details (optional):' %>
   <%= f.input :body, as: :hidden %>
-  <trix-editor input="event_body" placeholder="<%= @placeholders[:body] %>"></trix-editor>
+  <trix-editor input="event_body" placeholder="<%= @placeholders[:body] %>" data-upload-token="<%= @image_upload_token %>"></trix-editor>
 
   <br>
 

--- a/app/views/events_admin/edit.html.erb
+++ b/app/views/events_admin/edit.html.erb
@@ -1,6 +1,7 @@
 <h1>Edit your event</h1>
 
 <%= simple_form_for @event, url: event_admin_path(@event, @event.admin_token) do |f| %>
+  <%= hidden_field_tag :image_upload_token, @image_upload_token %>
   <%= f.input :title %>
 
   <%= f.input :date,
@@ -12,7 +13,7 @@
 
   <%= f.label :body, 'More details (optional):' %>
   <%= f.input :body, as: :hidden %>
-  <trix-editor input="event_body"></trix-editor>
+  <trix-editor input="event_body" data-upload-token="<%= @image_upload_token %>"></trix-editor>
 
   <br>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
+require_relative "../lib/upload_size_limiter"
 
 # require "action_cable/engine"
 # require "action_mailbox/engine"
@@ -39,6 +40,8 @@ module EasyRsvp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.middleware.insert_before 0, UploadSizeLimiter
 
     config.action_mailer.default_url_options = { host: ENV['DOMAIN'] }
     config.action_mailer.delivery_method = :smtp

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,6 +24,7 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
   config.cache_store = :null_store
+  config.action_controller.cache_store = :memory_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  post "/rails/active_storage/direct_uploads", to: "image_uploads#direct_upload_disabled"
+
   resources :events, path: '/', only: [:new, :create, :show] do
     resources :admin,
       controller: :events_admin,

--- a/db/migrate/20260909120000_add_ownership_to_image_uploads.rb
+++ b/db/migrate/20260909120000_add_ownership_to_image_uploads.rb
@@ -1,0 +1,7 @@
+class AddOwnershipToImageUploads < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :image_uploads, :event, foreign_key: true
+    add_column :image_uploads, :upload_session_digest, :string
+    add_index :image_uploads, :upload_session_digest
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_08_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_09_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -57,7 +57,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_140000) do
 
   create_table "image_uploads", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.bigint "event_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.string "upload_session_digest"
+    t.index ["event_id"], name: "index_image_uploads_on_event_id"
+    t.index ["upload_session_digest"], name: "index_image_uploads_on_upload_session_digest"
   end
 
   create_table "rsvps", force: :cascade do |t|
@@ -72,5 +76,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_140000) do
   add_check_constraint "rsvps", "response IS NOT NULL AND (response::text = ANY (ARRAY['yes'::character varying, 'maybe'::character varying, 'no'::character varying]::text[]))", name: "rsvps_supported_response", validate: false
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "image_uploads", "events"
   add_foreign_key "rsvps", "events"
 end

--- a/docs/CODEBASE_ASSESSMENT.md
+++ b/docs/CODEBASE_ASSESSMENT.md
@@ -443,9 +443,19 @@ provided; Bon App's accepted risks do not transfer.
   Prove redaction with synthetic tokens and review logging configurations. Merely
   adding another filtered parameter does not fix raw path logging.
 
-- [ ] **2.4 P1 — Bound and own public uploads.** Presence, detected content types,
-  a 10 MB limit, and recoverable upload errors are implemented. Ownership/expiry,
-  direct-upload policy, and request-level abuse controls remain. Original finding:
+- [x] **2.4 P1 — Bound and own public uploads.** Completed 2026-09-09. Editor
+  uploads now require a per-form capability and retain only its digest. Saving an
+  event claims only uploads whose signed blob URL remains in that editor body;
+  deleting the event removes its upload records and schedules normal Active
+  Storage blob purges. Unclaimed managed uploads become ineligible for claiming
+  after 24 hours and a production-only cleanup task purges them. Historical rows
+  without a capability digest are excluded so imported data is never treated as
+  abandoned by age alone. The unused direct-upload endpoint returns 404. A Rack
+  middleware rejects declared upload requests above 11 MB before multipart
+  parsing, and Rails limits the endpoint to 20 attempts per IP per minute through
+  its configured controller cache. Model, request, task, and real Firefox tests
+  cover ownership, expiry, cleanup, throttling, and persisted editor uploads.
+  Original finding:
   `ImageUploadsController#create` permits any file and `ImageUpload` has no
   presence/type/size validation. A public JSON upload of a plain text file returned
   200 and persisted it. The app also exposes Rails direct-upload routes. Define

--- a/lib/tasks/image_uploads.rake
+++ b/lib/tasks/image_uploads.rake
@@ -1,0 +1,11 @@
+namespace :image_uploads do
+  desc "Purge managed editor uploads that have been abandoned for at least 24 hours"
+  task purge_abandoned: :environment do
+    unless Rails.env.production? || Rails.env.test?
+      abort "Refusing to purge outside production; an imported development database may still reference production storage."
+    end
+
+    count = ImageUpload.purge_abandoned!
+    puts "Purged #{count} abandoned image upload#{'s' unless count == 1}."
+  end
+end

--- a/lib/upload_size_limiter.rb
+++ b/lib/upload_size_limiter.rb
@@ -1,0 +1,23 @@
+class UploadSizeLimiter
+  MAXIMUM_REQUEST_SIZE = 11.megabytes
+  PATH = %r{\A/image_uploads(?:\.[^/]+)?/?\z}
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env["REQUEST_METHOD"] == "POST" && env["PATH_INFO"].match?(PATH) && oversized?(env)
+      body = '{"image":["request is too large"]}'
+      return [413, { "content-type" => "application/json", "content-length" => body.bytesize.to_s }, [body]]
+    end
+
+    @app.call(env)
+  end
+
+  private
+
+  def oversized?(env)
+    env["CONTENT_LENGTH"].to_i > MAXIMUM_REQUEST_SIZE
+  end
+end

--- a/spec/lib/image_uploads_task_spec.rb
+++ b/spec/lib/image_uploads_task_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'image_uploads:purge_abandoned' do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('image_uploads:purge_abandoned')
+  end
+
+  let(:task) { Rake::Task['image_uploads:purge_abandoned'] }
+
+  before { task.reenable }
+
+  it 'reports and removes uploads whose managed claim window elapsed' do
+    upload = ImageUpload.new(upload_session_digest: ImageUpload.digest_token('abandoned'))
+    upload.image.attach(
+      io: File.open(Rails.root.join('spec/fixtures/files/party.png')),
+      filename: 'party.png',
+      content_type: 'image/png'
+    )
+    upload.save!
+    upload.update_column(:created_at, 24.hours.ago - 1.second)
+
+    expect { task.invoke }.to output("Purged 1 abandoned image upload.\n").to_stdout
+
+    expect(ImageUpload.exists?(upload.id)).to be(false)
+  end
+
+  it 'refuses to run against a development database that may be imported' do
+    allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new('development'))
+
+    expect { task.invoke }
+      .to raise_error(SystemExit)
+      .and output(/Refusing to purge outside production/).to_stderr
+  end
+end

--- a/spec/lib/upload_size_limiter_spec.rb
+++ b/spec/lib/upload_size_limiter_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe UploadSizeLimiter do
+  ['/image_uploads', '/image_uploads.json'].each do |path|
+    it "rejects oversized requests to #{path} before invoking Rails" do
+      downstream = instance_double('Rack application')
+      allow(downstream).to receive(:call)
+      limiter = described_class.new(downstream)
+      env = {
+        'REQUEST_METHOD' => 'POST',
+        'PATH_INFO' => path,
+        'CONTENT_LENGTH' => (described_class::MAXIMUM_REQUEST_SIZE + 1).to_s
+      }
+
+      status, headers, body = limiter.call(env)
+
+      expect(status).to eq(413)
+      expect(headers.fetch('content-type')).to eq('application/json')
+      expect(body.join).to include('request is too large')
+      expect(downstream).not_to have_received(:call)
+    end
+  end
+
+  it 'passes requests within the transport limit to Rails' do
+    downstream = instance_double('Rack application', call: [204, {}, []])
+    limiter = described_class.new(downstream)
+    env = {
+      'REQUEST_METHOD' => 'POST',
+      'PATH_INFO' => '/image_uploads',
+      'CONTENT_LENGTH' => described_class::MAXIMUM_REQUEST_SIZE.to_s
+    }
+
+    expect(limiter.call(env).first).to eq(204)
+    expect(downstream).to have_received(:call).with(env)
+  end
+end

--- a/spec/models/image_upload_spec.rb
+++ b/spec/models/image_upload_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe ImageUpload, type: :model do
     upload.image.attach(io: File.open(Rails.root.join('spec/fixtures/files/party.png')), filename: 'party.png', content_type: 'image/png')
   end
 
+  def create_upload(**attributes)
+    upload = described_class.new(attributes)
+    attach_image(upload)
+    upload.save!
+    upload
+  end
+
   it 'persists the image and original bytes to test disk storage' do
     upload = described_class.new
     attach_image(upload)
@@ -43,6 +50,41 @@ RSpec.describe ImageUpload, type: :model do
       expect(upload.valid?).to eq(size <= 10.megabytes)
       expect(upload.errors[:image]).to include('must be 10 MB or smaller') if size > 10.megabytes
     end
+  end
+
+  it 'finds only managed, unowned uploads older than 24 hours for cleanup' do
+    historical = create_upload
+    recent = create_upload(upload_session_digest: described_class.digest_token('recent'))
+    abandoned = create_upload(upload_session_digest: described_class.digest_token('abandoned'))
+    owned = create_upload(event: create(:event), upload_session_digest: nil)
+    abandoned.update_column(:created_at, 24.hours.ago - 1.second)
+    owned.update_column(:created_at, 2.days.ago)
+
+    expect(described_class.abandoned).to contain_exactly(abandoned)
+    expect(described_class.abandoned).not_to include(historical, recent, owned)
+  end
+
+  it 'purges abandoned managed records, blobs, and disk files' do
+    upload = create_upload(upload_session_digest: described_class.digest_token('abandoned'))
+    upload.update_column(:created_at, 24.hours.ago - 1.second)
+    blob = upload.image.blob
+
+    expect(described_class.purge_abandoned!).to eq(1)
+
+    expect(described_class.exists?(upload.id)).to be(false)
+    expect(ActiveStorage::Blob.exists?(blob.id)).to be(false)
+    expect(blob.service.exist?(blob.key)).to be(false)
+  end
+
+  it 'removes owned upload records and their blobs when the event is deleted' do
+    event = create(:event)
+    upload = create_upload(event: event)
+    blob = upload.image.blob
+
+    perform_enqueued_jobs { event.destroy! }
+
+    expect(described_class.exists?(upload.id)).to be(false)
+    expect(ActiveStorage::Blob.exists?(blob.id)).to be(false)
   end
 
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |config|
 
   config.before do
     ActionMailer::Base.deliveries.clear
+    ImageUploadsController.cache_store.clear
     clear_enqueued_jobs
     clear_performed_jobs
   end

--- a/spec/requests/image_upload_ownership_spec.rb
+++ b/spec/requests/image_upload_ownership_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe 'Image upload ownership', type: :request do
+  def start_editor
+    get root_path
+    editor = Nokogiri::HTML(response.body).at_css('trix-editor')
+    editor['data-upload-token']
+  end
+
+  def upload_image(token)
+    post image_uploads_path(format: :json), params: {
+      image_upload: { image: uploaded_image, token: token }
+    }
+    expect(response).to have_http_status(:ok)
+    [ImageUpload.order(:id).last, response.parsed_body.fetch('url')]
+  end
+
+  def create_event(token:, body:)
+    post events_path, params: {
+      image_upload_token: token,
+      event: { title: 'Upload ownership', date: '2026-10-10', body: body }
+    }
+  end
+
+  it 'assigns a referenced editor upload to the newly saved event' do
+    token = start_editor
+    upload, url = upload_image(token)
+    expect(upload.upload_session_digest).to eq(ImageUpload.digest_token(token))
+    expect(upload.upload_session_digest).not_to eq(token)
+
+    create_event(token: token, body: %(<figure><img src="#{url}"></figure>))
+
+    expect(response).to redirect_to(event_admin_path(Event.last, Event.last.admin_token))
+    expect(upload.reload).to have_attributes(event_id: Event.last.id, upload_session_digest: nil)
+  end
+
+  it 'does not assign an upload removed from the editor before save' do
+    token = start_editor
+    upload, = upload_image(token)
+
+    create_event(token: token, body: '<div>No image remains.</div>')
+
+    expect(upload.reload.event_id).to be_nil
+    expect(upload.upload_session_digest).to be_present
+  end
+
+  it 'keeps the same capability through validation errors and claims on retry' do
+    token = start_editor
+    upload, url = upload_image(token)
+
+    post events_path, params: {
+      image_upload_token: token,
+      event: { title: '', date: '2026-10-10', body: %(<img src="#{url}">) }
+    }
+    expect(response).to have_http_status(:ok)
+    expect(Nokogiri::HTML(response.body).at_css('trix-editor')['data-upload-token']).to eq(token)
+    expect(upload.reload.event_id).to be_nil
+
+    create_event(token: token, body: %(<img src="#{url}">))
+    expect(upload.reload.event).to eq(Event.last)
+  end
+
+  it 'does not let another open editor claim an upload' do
+    first_token = start_editor
+    upload, url = upload_image(first_token)
+    second_token = start_editor
+
+    create_event(token: second_token, body: %(<img src="#{url}">))
+
+    expect(upload.reload.event_id).to be_nil
+  end
+
+  it 'does not claim an upload after its 24-hour window' do
+    token = start_editor
+    upload, url = upload_image(token)
+
+    travel 24.hours + 1.second do
+      create_event(token: token, body: %(<img src="#{url}">))
+      expect(upload.reload.event_id).to be_nil
+      expect(ImageUpload.abandoned).to include(upload)
+    end
+  end
+
+  it 'retires a capability after a successful save' do
+    token = start_editor
+    create_event(token: token, body: '')
+
+    expect do
+      post image_uploads_path(format: :json), params: {
+        image_upload: { image: uploaded_image, token: token }
+      }
+    end.not_to change(ImageUpload, :count)
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it 'assigns a newly referenced upload when an organizer saves an edit' do
+    event = create(:event)
+    get edit_event_admin_path(event, event.admin_token)
+    token = Nokogiri::HTML(response.body).at_css('trix-editor')['data-upload-token']
+    upload, url = upload_image(token)
+
+    patch event_admin_path(event, event.admin_token), params: {
+      image_upload_token: token,
+      event: { title: event.title, date: event.date, body: %(<img src="#{url}">) }
+    }
+
+    expect(response).to redirect_to(event_admin_path(event, event.admin_token))
+    expect(upload.reload.event).to eq(event)
+  end
+end

--- a/spec/requests/image_uploads_spec.rb
+++ b/spec/requests/image_uploads_spec.rb
@@ -1,9 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe 'Image upload integration', type: :request do
+  def upload_token
+    get root_path
+    Nokogiri::HTML(response.body).at_css('trix-editor')['data-upload-token']
+  end
+
+  def upload_params(image: uploaded_image, token: upload_token, **extra)
+    { image_upload: { image: image, token: token }.merge(extra) }
+  end
+
   it 'accepts an image and returns a working download URL with its original bytes' do
     expect do
-      post image_uploads_path(format: :json), params: { image_upload: { image: uploaded_image } }
+      post image_uploads_path(format: :json), params: upload_params
     end.to change(ImageUpload, :count).by(1).and change(ActiveStorage::Blob, :count).by(1)
     expect(response).to have_http_status(:ok)
     url = response.parsed_body.fetch('url')
@@ -17,14 +26,22 @@ RSpec.describe 'Image upload integration', type: :request do
 
   it 'does not require an event to have been saved before uploading editor content' do
     expect do
-      post image_uploads_path(format: :json), params: { image_upload: { image: uploaded_image } }
+      post image_uploads_path(format: :json), params: upload_params
     end.not_to change(Event, :count)
     expect(response).to have_http_status(:ok)
   end
 
   it 'does not accept mass-assignment of an upload record ID' do
-    post image_uploads_path(format: :json), params: { image_upload: { image: uploaded_image, id: 12345678 } }
+    post image_uploads_path(format: :json), params: upload_params(id: 12345678)
     expect(ImageUpload.order(:id).last.id).not_to eq(12345678)
+  end
+
+  it 'requires a capability issued by an event editor' do
+    expect do
+      post image_uploads_path(format: :json), params: upload_params(token: 'not-issued')
+    end.not_to change(ImageUpload, :count)
+    expect(response).to have_http_status(:forbidden)
+    expect(ActiveStorage::Blob.count).to eq(0)
   end
 
   it 'rejects a missing upload parameter object without creating records' do
@@ -35,7 +52,7 @@ RSpec.describe 'Image upload integration', type: :request do
   it 'rejects a non-image even when its submitted MIME type claims it is a PNG' do
     file = fixture_file_upload(Rails.root.join('spec/fixtures/files/notes.txt'), 'image/png')
     expect do
-      post image_uploads_path(format: :json), params: { image_upload: { image: file } }
+      post image_uploads_path(format: :json), params: upload_params(image: file)
     end.not_to change(ImageUpload, :count)
     expect(response).to have_http_status(:unprocessable_entity)
     expect(response.parsed_body.fetch('image')).to be_present
@@ -44,9 +61,30 @@ RSpec.describe 'Image upload integration', type: :request do
 
   it 'rejects a blank file without leaving an upload record behind' do
     expect do
-      post image_uploads_path(format: :json), params: { image_upload: { image: '' } }
+      post image_uploads_path(format: :json), params: upload_params(image: '')
     end.not_to change(ImageUpload, :count)
     expect(response).to have_http_status(:unprocessable_entity)
   end
 
+  it 'disables the unused Active Storage direct-upload endpoint' do
+    expect do
+      post rails_active_storage_direct_uploads_path, params: {
+        blob: { filename: 'party.png', byte_size: 100, checksum: 'unused', content_type: 'image/png' }
+      }
+    end.not_to change(ActiveStorage::Blob, :count)
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'limits upload bursts by IP address' do
+    token = upload_token
+    20.times do
+      post image_uploads_path(format: :json), params: upload_params(token: token)
+      expect(response).to have_http_status(:ok)
+    end
+
+    expect do
+      post image_uploads_path(format: :json), params: upload_params(token: token)
+    end.not_to change(ImageUpload, :count)
+    expect(response).to have_http_status(:too_many_requests)
+  end
 end

--- a/spec/system/javascript_smoke_spec.rb
+++ b/spec/system/javascript_smoke_spec.rb
@@ -53,8 +53,12 @@ RSpec.describe 'Firefox JavaScript smoke', type: :system, js: true do
     expect(page).to have_css('trix-editor img[src*="/rails/active_storage/"]')
     expect_loaded_image('trix-editor img')
     expect(ImageUpload.count).to eq(1)
+    upload = ImageUpload.last
+    expect(upload.event_id).to be_nil
     expect(ActiveStorage::Blob.last.service_name).to eq('test')
     click_button 'Create your event, for free!'
+    expect(upload.reload.event).to eq(Event.last)
+    expect(upload.upload_session_digest).to be_nil
     expect_loaded_image('.trix-content img')
     click_link 'public-link'
     page.refresh


### PR DESCRIPTION
Public editor uploads previously had no event owner or expiry: any client could call the endpoint, removed images accumulated indefinitely, and deleting an event could not clean up its files.

Issue a per-editor upload capability and store only its digest on new uploads. Event create/update claims only recent uploads from that capability whose signed blob URL remains in the saved Trix body. Claimed uploads belong to the event and are removed through the normal Active Storage lifecycle when the event is deleted. Unclaimed managed uploads expire after 24 hours and can be purged with the production-only `bin/rails image_uploads:purge_abandoned` task; historical unowned rows remain excluded.

The PR also returns 404 from the unused Active Storage direct-upload endpoint, rejects declared upload requests over an 11 MB transport envelope before multipart parsing, and limits uploads to 20 attempts per IP per minute through the Rails controller cache.

Validation: `CI=true bin/ci` passes 212 examples with no failures, including real Firefox Trix upload/save/reload coverage. The migration passed down/up against `events_test`. Focused coverage verifies create/edit ownership, cross-editor isolation, validation retries, token retirement, 24-hour expiry, historical-row preservation, cleanup, event deletion, direct-upload rejection, throttling, and both plain and `.json` request-size paths.

After deployment, configure the production scheduler to run `bin/rails image_uploads:purge_abandoned` hourly.
