### PR TITLE
Validate historical RSVP response values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ eager-loading, asset-compilation, and RSpec checks.
   publication and RSVP-name visibility flags, dependent destruction of RSVPs.
 - `Rsvp`: belongs to an event, name/response presence validation,
   `RESPONSES = [:yes, :maybe, :no]`, with inclusion validation and a database check
-  for new writes. Historical rows still need review before validating the constraint.
+  that is validated against existing rows as well as enforced for new writes.
 - `ImageUpload`: one required PNG/JPEG/GIF/WebP image, at most 10 MB. The upload
   endpoint detects MIME type from file bytes. Upload ownership remains independent
   of event creation and needs a separate lifecycle design.

--- a/README.md
+++ b/README.md
@@ -78,10 +78,9 @@ PNG/JPEG/GIF/WebP content and a maximum size of 10 MB; failed Trix uploads show 
 error and permit another attempt. Production email links require `DOMAIN` (a host
 without a URL scheme) and use HTTPS.
 
-The RSVP migration enforces supported response values on new writes using a
-PostgreSQL `NOT VALID` check constraint. It leaves historical records unchanged;
-review any invalid values before validating the existing rows in a later migration.
-The migration has been applied and reversed only against the local test database.
+The RSVP migrations enforce supported response values with a validated PostgreSQL
+check constraint. An aggregate review of the production-derived development data
+found no invalid responses, so validation required no data cleanup or coercion.
 
 The admin dashboard shows the all-time total with its earliest creation date,
 current-year count and projection, and current-month count and projection alongside

--- a/db/migrate/20260909130356_validate_supported_response_constraint_on_rsvps.rb
+++ b/db/migrate/20260909130356_validate_supported_response_constraint_on_rsvps.rb
@@ -1,0 +1,10 @@
+class ValidateSupportedResponseConstraintOnRsvps < ActiveRecord::Migration[8.1]
+  def up
+    validate_check_constraint :rsvps, name: "rsvps_supported_response"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+      "PostgreSQL cannot mark a validated constraint NOT VALID without recreating it"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_08_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_09_130356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -67,9 +67,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_140000) do
     t.string "response"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["event_id"], name: "index_rsvps_on_event_id"
+    t.check_constraint "response IS NOT NULL AND (response::text = ANY (ARRAY['yes'::character varying::text, 'maybe'::character varying::text, 'no'::character varying::text]))", name: "rsvps_supported_response"
   end
-
-  add_check_constraint "rsvps", "response IS NOT NULL AND (response::text = ANY (ARRAY['yes'::character varying, 'maybe'::character varying, 'no'::character varying]::text[]))", name: "rsvps_supported_response", validate: false
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "rsvps", "events"

--- a/docs/CODEBASE_ASSESSMENT.md
+++ b/docs/CODEBASE_ASSESSMENT.md
@@ -8,6 +8,13 @@ Status: **assessment and Phase 0 coverage complete; original pending regressions
 initial assessment brief. Standards: [Rails Engineering Playbook](RAILS_ENGINEERING_PLAYBOOK.md).
 Application reference: [AGENTS.md](../AGENTS.md).
 
+## RSVP response constraint validation — 2026-09-09
+
+The production-derived development database contained 88,330 RSVPs and no null
+or unsupported response values. The existing `rsvps_supported_response` check is
+now validated for historical rows as well as enforced for new writes. No response
+data was rewritten or coerced. Validation completed locally in 18 milliseconds.
+
 ## Dependency security remediation — 2026-09-09
 
 Rails is updated to 8.1.3.1 and rubyzip to 3.6.0. The unused
@@ -44,12 +51,11 @@ upload followed by a successful upload, and injected transport failures followed
 by retries through the actual endpoint/storage. The database migration was tested
 up/down/up only against `events_test`. No production data was accessed or changed.
 
-The response constraint is intentionally `NOT VALID`: it protects new writes
-without scanning, rewriting, or silently coercing historical responses. Item 1.4
-remains partial until old invalid values are reviewed and the constraint is
-validated. Upload ownership/expiry, direct-upload route policy, and request-level
-abuse limits also remain in 2.4. Dependency patches, vendored Trix replacement,
-log redaction, and the other unchecked assessment items are separate work.
+The response constraint was initially added as `NOT VALID` so new writes were
+protected without scanning, rewriting, or silently coercing historical responses.
+Item 1.4 was completed after the aggregate review described above. Upload
+ownership/expiry, direct-upload route policy, and request-level abuse limits remain
+deferred in 2.4. Other unchecked assessment items remain separate work.
 
 Earlier sections below are dated evidence snapshots, including their historical
 pending counts and descriptions of defects before these fixes.
@@ -368,9 +374,10 @@ provided; Bon App's accepted risks do not transfer.
   Repeated use grows stale session data. Store the reduced array or delete an
   empty key; test both database state and subsequent session contents.
 
-- [ ] **1.4 P1 — Validate response membership.** Model validation and the check
-  constraint for new writes are implemented. Remaining: review historical invalid
-  responses and validate the constraint; no automatic data coercion. Original finding: `app/models/rsvp.rb:13` only
+- [x] **1.4 P1 — Validate response membership.** Model validation and the check
+  constraint protect new writes. An aggregate review found zero invalid responses
+  among 88,330 production-derived rows, and the constraint is now validated without
+  modifying historical data. Original finding: `app/models/rsvp.rb:13` only
   validates response presence. The organizer endpoint permits `response`
   (`app/controllers/admin/rsvps_controller.rb:26`). A PATCH with `unexpected`
   persists successfully; the public view only groups yes/maybe/no and omits
@@ -460,8 +467,9 @@ provided; Bon App's accepted risks do not transfer.
   adding another filtered parameter does not fix raw path logging.
 
 - [ ] **2.4 P1 — Bound and own public uploads.** Presence, detected content types,
-  a 10 MB limit, and recoverable upload errors are implemented. Ownership/expiry,
-  direct-upload policy, and request-level abuse controls remain. Original finding:
+  a 10 MB limit, and recoverable upload errors are implemented. The owner deferred
+  ownership/expiry and purge scheduling on 2026-09-09. Direct-upload policy and
+  request-level abuse controls remain separate follow-ups. Original finding:
   `ImageUploadsController#create` permits any file and `ImageUpload` has no
   presence/type/size validation. A public JSON upload of a plain text file returned
   200 and persisted it. The app also exposes Rails direct-upload routes. Define

--- a/spec/models/rsvp_spec.rb
+++ b/spec/models/rsvp_spec.rb
@@ -59,4 +59,11 @@ RSpec.describe Rsvp, type: :model do
     end
   end
 
+  it 'has a validated database constraint for supported responses' do
+    constraint = ActiveRecord::Base.connection.check_constraints(:rsvps)
+      .find { |candidate| candidate.name == 'rsvps_supported_response' }
+
+    expect(constraint).to be_present
+    expect(constraint.options[:validate]).to be(true)
+  end
 end


### PR DESCRIPTION
Validate the existing RSVP response check against historical rows so unsupported or null responses cannot remain hidden from the public response groups. A read-only aggregate review of the production-derived development database found 0 invalid responses among 88,330 RSVPs, so this migration validates the existing PostgreSQL constraint without rewriting or coercing data.

The migration has an explicit irreversible rollback because PostgreSQL cannot return a validated constraint to `NOT VALID` without dropping and recreating it. Validation completed against the local 88,330-row database in 18 ms. The assessment also records the owner's decision to defer upload ownership, expiry, and purge scheduling.

Validation:
- Applied the migration to test and the production-derived development database
- Recreated `events_test` from `db/schema.rb` and ran the focused model spec: 15 examples, 0 failures
- `CI=true bin/ci`: dependency audits clean, Brakeman 0 warnings, eager load and assets pass, 201 examples and 0 failures
